### PR TITLE
Display tokens in Assets screen

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -74,7 +74,7 @@
     "@tippyjs/react": "^4.2.6",
     "@alephium/web3": "0.2.0-rc.33",
     "@alephium/web3-wallet": "0.2.0-rc.33",
-    "@alephium/sdk": "0.1.0",
+    "@alephium/sdk": "0.2.0-rc.0",
     "crypto-browserify": "3.12.0",
     "stream-browserify": "3.0.0",
     "bignumber.js": "^9.0.2",

--- a/packages/extension/src/background/addressMessaging.ts
+++ b/packages/extension/src/background/addressMessaging.ts
@@ -1,5 +1,5 @@
-import { AddressToken } from '../shared/addresses'
 import { AddressMessage } from '../shared/messages/AddressMessage'
+import { AddressToken } from '../shared/tokens'
 import { sendMessageToUi } from './activeTabs'
 import { HandleMessage, UnhandledMessage } from './background'
 import { encryptForUi } from './crypto'
@@ -121,12 +121,7 @@ export const handleAddressMessage: HandleMessage<AddressMessage> = async ({
               balance: {
                 balance: BigInt(addressTokenBalance.balance),
                 lockedBalance: BigInt(addressTokenBalance.lockedBalance)
-              },
-              // TODO: Get ticker and name from https://github.com/alephium/tokens-meta
-              ticker: `TK${addressToken.slice(0, 2)}`,
-              name: addressToken,
-              decimals: 0,
-              logo: `https://picsum.photos/20${Math.floor(Math.random() * 10)}`
+              }
             })
           }
         }

--- a/packages/extension/src/background/addressMessaging.ts
+++ b/packages/extension/src/background/addressMessaging.ts
@@ -79,8 +79,6 @@ export const handleAddressMessage: HandleMessage<AddressMessage> = async ({
     }
 
     case 'GET_ADDRESS_TOKENS': {
-      console.log('GET_ADDRESS_TOKENS')
-
       const tokens = await wallet.getAddressTokens(msg.data.address)
 
       return sendToTabAndUi({
@@ -90,7 +88,6 @@ export const handleAddressMessage: HandleMessage<AddressMessage> = async ({
     }
 
     case 'GET_ADDRESS_TOKEN_BALANCE': {
-      console.log('GET_ADDRESS_TOKEN_BALANCE')
       const { address, tokenId } = msg.data
       const tokens = await wallet.getAddressTokenBalance(address, tokenId)
 
@@ -101,8 +98,6 @@ export const handleAddressMessage: HandleMessage<AddressMessage> = async ({
     }
 
     case 'GET_ADDRESSES_TOKENS_BALANCE': {
-      console.log('GET_ADDRESSES_TOKENS_BALANCE')
-
       const tokens: AddressToken[] = []
 
       for (const address of msg.data.addresses) {

--- a/packages/extension/src/background/addressMessaging.ts
+++ b/packages/extension/src/background/addressMessaging.ts
@@ -123,7 +123,7 @@ export const handleAddressMessage: HandleMessage<AddressMessage> = async ({
                 lockedBalance: BigInt(addressTokenBalance.lockedBalance)
               },
               // TODO: Get ticker and name from https://github.com/alephium/tokens-meta
-              ticker: addressToken.slice(0, 3),
+              ticker: `TK${addressToken.slice(0, 2)}`,
               name: addressToken,
               decimals: 0,
               logo: `https://picsum.photos/20${Math.floor(Math.random() * 10)}`

--- a/packages/extension/src/background/addressMessaging.ts
+++ b/packages/extension/src/background/addressMessaging.ts
@@ -124,7 +124,9 @@ export const handleAddressMessage: HandleMessage<AddressMessage> = async ({
               },
               // TODO: Get ticker and name from https://github.com/alephium/tokens-meta
               ticker: addressToken.slice(0, 3),
-              name: addressToken
+              name: addressToken,
+              decimals: 0,
+              logo: `https://picsum.photos/20${Math.floor(Math.random() * 10)}`
             })
           }
         }

--- a/packages/extension/src/background/transactions/transactionMessaging.ts
+++ b/packages/extension/src/background/transactions/transactionMessaging.ts
@@ -17,6 +17,15 @@ export const handleTransactionMessage: HandleMessage<TransactionMessage> = async
       })
     }
 
+    case 'GET_ADDRESS_TOKEN_TRANSACTIONS': {
+      const transactions = await wallet.getAddressTokenTransactions(msg.data.address, msg.data.tokenId)
+
+      return sendToTabAndUi({
+        type: 'GET_ADDRESS_TOKEN_TRANSACTIONS_RES',
+        data: transactions
+      })
+    }
+
     case 'EXECUTE_TRANSACTION': {
       const { meta } = await actionQueue.push({
         type: 'TRANSACTION',

--- a/packages/extension/src/background/wallet.ts
+++ b/packages/extension/src/background/wallet.ts
@@ -158,6 +158,11 @@ export class Wallet {
     return await explorerProvider.addresses.getAddressesAddressTokensTokenIdBalance(address, tokenId)
   }
 
+  public async getAddressTokenTransactions(address: string, tokenId: string): Promise<Transaction[]> {
+    const explorerProvider = await this.getExplorerProvider()
+    return await explorerProvider.addresses.getAddressesAddressTokensTokenIdTransactions(address, tokenId)
+  }
+
   public async selectAlephiumAddress(address: string) {
     const addresses = await this.getAlephiumAddresses()
 

--- a/packages/extension/src/background/wallet.ts
+++ b/packages/extension/src/background/wallet.ts
@@ -148,6 +148,16 @@ export class Wallet {
     return value
   }
 
+  public async getAddressTokens(address: string): Promise<string[]> {
+    const explorerProvider = await this.getExplorerProvider()
+    return await explorerProvider.addresses.getAddressesAddressTokens(address)
+  }
+
+  public async getAddressTokenBalance(address: string, tokenId: string): Promise<AddressBalance> {
+    const explorerProvider = await this.getExplorerProvider()
+    return await explorerProvider.addresses.getAddressesAddressTokensTokenIdBalance(address, tokenId)
+  }
+
   public async selectAlephiumAddress(address: string) {
     const addresses = await this.getAlephiumAddresses()
 

--- a/packages/extension/src/shared/addresses.ts
+++ b/packages/extension/src/shared/addresses.ts
@@ -15,6 +15,8 @@ export type AddressToken = {
     balance: bigint
     lockedBalance: bigint
   }
+  decimals: number
+  logo?: string
 }
 
 export class Address {

--- a/packages/extension/src/shared/addresses.ts
+++ b/packages/extension/src/shared/addresses.ts
@@ -7,18 +7,6 @@ export type TimeInMs = number
 
 export type AddressHash = string
 
-export type AddressToken = {
-  id: string
-  ticker: string
-  name: string
-  balance: {
-    balance: bigint
-    lockedBalance: bigint
-  }
-  decimals: number
-  logo?: string
-}
-
 export class Address {
   readonly hash: AddressHash
   readonly shortHash: string

--- a/packages/extension/src/shared/addresses.ts
+++ b/packages/extension/src/shared/addresses.ts
@@ -7,6 +7,16 @@ export type TimeInMs = number
 
 export type AddressHash = string
 
+export type AddressToken = {
+  id: string
+  ticker: string
+  name: string
+  balance: {
+    balance: bigint
+    lockedBalance: bigint
+  }
+}
+
 export class Address {
   readonly hash: AddressHash
   readonly shortHash: string

--- a/packages/extension/src/shared/messages/AddressMessage.ts
+++ b/packages/extension/src/shared/messages/AddressMessage.ts
@@ -1,6 +1,6 @@
 import { AddressBalance } from '@alephium/sdk/api/explorer'
 
-import { AddressAndPublicKey } from '../addresses'
+import { AddressAndPublicKey, AddressToken } from '../addresses'
 
 export type AddressMessage =
   | { type: 'NEW_ADDRESS'; data?: number }
@@ -28,6 +28,12 @@ export type AddressMessage =
       type: 'GET_ADDRESSES_BALANCE_RES'
       data: AddressBalance[]
     }
+  | { type: 'GET_ADDRESS_TOKENS'; data: { address: string } }
+  | { type: 'GET_ADDRESS_TOKENS_RES'; data: string[] }
+  | { type: 'GET_ADDRESS_TOKEN_BALANCE'; data: { address: string; tokenId: string } }
+  | { type: 'GET_ADDRESS_TOKEN_BALANCE_RES'; data: AddressBalance }
+  | { type: 'GET_ADDRESSES_TOKENS_BALANCE'; data: { addresses: string[] } }
+  | { type: 'GET_ADDRESSES_TOKENS_BALANCE_RES'; data: AddressToken[] }
   | { type: 'DELETE_ADDRESS'; data: { address: string } }
   | { type: 'DELETE_ADDRESS_RES' }
   | { type: 'DELETE_ADDRESS_REJ' }

--- a/packages/extension/src/shared/messages/AddressMessage.ts
+++ b/packages/extension/src/shared/messages/AddressMessage.ts
@@ -1,6 +1,7 @@
 import { AddressBalance } from '@alephium/sdk/api/explorer'
 
-import { AddressAndPublicKey, AddressToken } from '../addresses'
+import { AddressAndPublicKey } from '../addresses'
+import { AddressToken } from '../tokens'
 
 export type AddressMessage =
   | { type: 'NEW_ADDRESS'; data?: number }

--- a/packages/extension/src/shared/messages/TransactionMessage.ts
+++ b/packages/extension/src/shared/messages/TransactionMessage.ts
@@ -51,6 +51,8 @@ export type TransactionPayload =
 export type TransactionMessage =
   | { type: 'GET_TRANSACTIONS'; data: { address: string } }
   | { type: 'GET_TRANSACTIONS_RES'; data: AlephiumTransaction[] }
+  | { type: 'GET_ADDRESS_TOKEN_TRANSACTIONS'; data: { address: string; tokenId: string } }
+  | { type: 'GET_ADDRESS_TOKEN_TRANSACTIONS_RES'; data: AlephiumTransaction[] }
   | {
       type: 'EXECUTE_TRANSACTION'
       data: TransactionPayload

--- a/packages/extension/src/shared/tokens.ts
+++ b/packages/extension/src/shared/tokens.ts
@@ -1,0 +1,15 @@
+export type AddressToken = {
+  id: string
+  balance: {
+    balance: bigint
+    lockedBalance: bigint
+  }
+}
+
+export type TokenMetadata = {
+  name: string
+  description: string
+  image: string
+  symbol: string
+  decimals: number
+}

--- a/packages/extension/src/shared/transactions/transactions.ts
+++ b/packages/extension/src/shared/transactions/transactions.ts
@@ -16,9 +16,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { MIN_UTXO_SET_AMOUNT, calAmountDelta } from '@alephium/sdk'
+import { MIN_UTXO_SET_AMOUNT, isConsolidationTx } from '@alephium/sdk'
 import { Input, Output, Transaction, UnconfirmedTransaction } from '@alephium/sdk/api/explorer'
-import { uniq } from 'lodash'
 
 import { Address } from '../addresses'
 
@@ -75,9 +74,6 @@ export const hasOnlyInputsWith = (inputs: Input[], addresses: Address[]): boolea
 export const hasOnlyOutputsWith = (outputs: Output[], addresses: Address[]): boolean =>
   outputs.every((o) => o?.address && addresses.map((a) => a.hash).indexOf(o.address) >= 0)
 
-export const getDirection = (tx: Transaction, address: AddressHash): TransactionDirection =>
-  calAmountDelta(tx, address) < 0 ? 'out' : 'in'
-
 export const calculateUnconfirmedTxSentAmount = (tx: UnconfirmedTransaction, address: AddressHash): bigint => {
   if (!tx.inputs || !tx.outputs) {
     throw 'Missing transaction details'
@@ -95,13 +91,6 @@ export const calculateUnconfirmedTxSentAmount = (tx: UnconfirmedTransaction, add
   )
 
   return totalOutputAmount - totalOutputAmountOfAddress
-}
-
-export const isConsolidationTx = (tx: Transaction | UnconfirmedTransaction): boolean => {
-  const inputAddresses = tx.inputs ? uniq(tx.inputs.map((input) => input.address)) : []
-  const outputAddresses = tx.outputs ? uniq(tx.outputs.map((output) => output.address)) : []
-
-  return inputAddresses.length === 1 && outputAddresses.length === 1 && inputAddresses[0] === outputAddresses[0]
 }
 
 // It can currently only take care of sending transactions.

--- a/packages/extension/src/ui/components/Amount.tsx
+++ b/packages/extension/src/ui/components/Amount.tsx
@@ -32,6 +32,7 @@ interface AmountProps {
   suffix?: string
   fiat?: number
   fiatCurrency?: Currency
+  token?: string
   className?: string
 }
 
@@ -43,6 +44,7 @@ const Amount = ({
   prefix,
   suffix,
   fiatCurrency,
+  token,
   fiat
 }: AmountProps) => {
   const theme = useTheme()
@@ -69,28 +71,30 @@ const Amount = ({
     fractionalPart = amountParts[1]
   }
 
-  const displaySuffix = moneySymbol && suffix ? ` ${suffix}` : fiatCurrency ? ` ${fiatCurrency}` : ''
+  const displaySuffix = `${moneySymbol}${
+    suffix ? ` ${suffix}` : token ? ` ${token}` : fiatCurrency ? ` ${fiatCurrency}` : ''
+  }`
 
   return (
     <span className={className}>
       <>
         {amount !== undefined ? (
-          fadeDecimals ? (
-            <>
-              {prefix && <span>{prefix}</span>}
-              <span>{integralPart}</span>
-              <FadedPart>
-                .{fractionalPart}
-                {displaySuffix && <span>{displaySuffix}</span>}
-              </FadedPart>
-            </>
-          ) : (
-            `${integralPart}.${fractionalPart}`
-          )
+          <>
+            {fadeDecimals ? (
+              <>
+                {prefix && <span>{prefix}</span>}
+                <span>{integralPart}</span>
+                <FadedPart>.{fractionalPart}</FadedPart>
+              </>
+            ) : (
+              `${integralPart}.${fractionalPart}`
+            )}
+            {displaySuffix && <FadedPart>{displaySuffix}</FadedPart>}
+          </>
         ) : (
           '-'
         )}
-        {value && (
+        {value && !token && (
           <FadedPart>
             <AlefSymbol color={theme.font.primary} />
           </FadedPart>

--- a/packages/extension/src/ui/features/assets/WalletAssetsScreen.tsx
+++ b/packages/extension/src/ui/features/assets/WalletAssetsScreen.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect, useState } from 'react'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 import { AddressToken } from '../../../shared/addresses'
 import { attoAlphToFiat } from '../../../shared/utils/amount'
@@ -108,30 +108,14 @@ const TokensListSection = styled.div`
 const TokensList = styled.div``
 
 // TODO: Consider merging with TXDetailsWrapper and TXWrapper
-const TokenItem = styled.div<{ highlighted?: boolean }>`
+const TokenItem = styled.div`
   display: flex;
   align-items: center;
   gap: 16px;
   padding: 16px 24px;
-  cursor: pointer;
-
-  transition: all 200ms ease-in-out;
 
   width: 100%;
   justify-content: space-between;
-
-  cursor: pointer;
-
-  ${({ highlighted }) =>
-    highlighted &&
-    css`
-      background-color: rgba(255, 255, 255, 0.1);
-    `}
-
-  &:hover, &:focus {
-    outline: 0;
-    background-color: rgba(255, 255, 255, 0.15);
-  }
 `
 
 const LeftGroup = styled.div`

--- a/packages/extension/src/ui/features/assets/WalletAssetsScreen.tsx
+++ b/packages/extension/src/ui/features/assets/WalletAssetsScreen.tsx
@@ -1,10 +1,11 @@
 import { FC, useEffect, useState } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
+import { AddressToken } from '../../../shared/addresses'
 import { attoAlphToFiat } from '../../../shared/utils/amount'
 import Amount from '../../components/Amount'
-import { getBalances } from '../../services/backgroundAddresses'
-import { H1, H3 } from '../../theme/Typography'
+import { getAddressesTokensBalance, getBalances } from '../../services/backgroundAddresses'
+import { DividerTitle, H1, H3 } from '../../theme/Typography'
 import { useAddresses } from '../addresses/addresses.state'
 import { useNetworkState } from '../networks/networks.state'
 import { useWalletState } from '../wallet/wallet.state'
@@ -16,12 +17,19 @@ interface WalletAssetsScreenProps {
 const WalletAssetsScreen: FC<WalletAssetsScreenProps> = ({ className }) => {
   const { addresses } = useAddresses()
   const [totalBalance, setTotalBalance] = useState<bigint | undefined>(undefined)
+  const [tokens, setTokens] = useState<AddressToken[]>()
   const [fiatBalance, setFiatBalance] = useState<number>()
   const { switcherNetworkId } = useNetworkState()
 
   useEffect(() => {
-    getBalances(addresses.map((a) => a.hash)).then((balances) => {
+    const addressHashes = addresses.map((a) => a.hash)
+
+    getBalances(addressHashes).then((balances) => {
       setTotalBalance(balances.reduce((acc, b) => acc + BigInt(b.balance), BigInt(0)))
+    })
+
+    getAddressesTokensBalance(addressHashes).then((tokens) => {
+      setTokens(tokens)
     })
   }, [addresses, switcherNetworkId])
 
@@ -42,12 +50,34 @@ const WalletAssetsScreen: FC<WalletAssetsScreenProps> = ({ className }) => {
 
   return (
     <div className={className} data-testid="address-tokens">
-      <H1>
-        <Amount value={totalBalance} fadeDecimals />
-      </H1>
-      <CenteredH3>
-        <Amount fiat={fiatBalance} fiatCurrency={'USD'} fadeDecimals />
-      </CenteredH3>
+      <div>
+        <H1>
+          <Amount value={totalBalance} fadeDecimals />
+        </H1>
+        <CenteredH3>
+          <Amount fiat={fiatBalance} fiatCurrency={'USD'} fadeDecimals />
+        </CenteredH3>
+      </div>
+      {tokens && tokens.length > 0 && (
+        <TokensListSection>
+          <DividerTitle>Tokens</DividerTitle>
+          <TokensList>
+            {tokens.map(({ id, ticker, name, balance }) => {
+              const totalBalance = balance.balance + balance.lockedBalance
+
+              return (
+                <TokenItem key={id}>
+                  <LeftGroup>
+                    <TokenIcon>{ticker}</TokenIcon>
+                    <TokenName>{name}</TokenName>
+                  </LeftGroup>
+                  <TokenAmount token={ticker} value={totalBalance} fadeDecimals />
+                </TokenItem>
+              )
+            })}
+          </TokensList>
+        </TokensListSection>
+      )}
     </div>
   )
 }
@@ -60,4 +90,79 @@ export default styled(WalletAssetsScreen)`
 
 const CenteredH3 = styled(H3)`
   text-align: center;
+`
+
+const TokensListSection = styled.div`
+  margin-top: 8px;
+`
+
+// TODO: Consider merging with TransactionsWrapper
+const TokensList = styled.div``
+
+// TODO: Consider merging with TXDetailsWrapper and TXWrapper
+const TokenItem = styled.div<{ highlighted?: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 24px;
+  cursor: pointer;
+
+  transition: all 200ms ease-in-out;
+
+  width: 100%;
+  justify-content: space-between;
+
+  cursor: pointer;
+
+  ${({ highlighted }) =>
+    highlighted &&
+    css`
+      background-color: rgba(255, 255, 255, 0.1);
+    `}
+
+  &:hover, &:focus {
+    outline: 0;
+    background-color: rgba(255, 255, 255, 0.15);
+  }
+`
+
+const LeftGroup = styled.div`
+  display: flex;
+  gap: 17px;
+  align-items: center;
+  min-width: 0;
+`
+
+const TokenIcon = styled.div`
+  width: 45px;
+  height: 45px;
+  border-radius: 45px;
+  background-color: ${({ theme }) => theme.bg.highlight};
+  color: ${({ theme }) => theme.font.contrast};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  flex-shrink: 0;
+`
+
+const TokenAmount = styled(Amount)`
+  font-weight: 600;
+  font-size: 17px;
+  flex-grow: 1;
+  flex-shrink: 0;
+  text-align: right;
+`
+
+// TODO: Consider merging with TXTitle
+const TokenName = styled.div`
+  font-weight: 600;
+  font-size: 17px;
+  line-height: 22px;
+  margin: 0;
+
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 250px;
 `

--- a/packages/extension/src/ui/features/assets/WalletAssetsScreen.tsx
+++ b/packages/extension/src/ui/features/assets/WalletAssetsScreen.tsx
@@ -14,6 +14,9 @@ interface WalletAssetsScreenProps {
   className?: string
 }
 
+// TODO: Get from js-sdk
+const NUM_OF_ZEROS_IN_QUINTILLION = 18
+
 const WalletAssetsScreen: FC<WalletAssetsScreenProps> = ({ className }) => {
   const { addresses } = useAddresses()
   const [totalBalance, setTotalBalance] = useState<bigint | undefined>(undefined)
@@ -62,16 +65,21 @@ const WalletAssetsScreen: FC<WalletAssetsScreenProps> = ({ className }) => {
         <TokensListSection>
           <DividerTitle>Tokens</DividerTitle>
           <TokensList>
-            {tokens.map(({ id, ticker, name, balance }) => {
-              const totalBalance = balance.balance + balance.lockedBalance
+            {tokens.map(({ id, ticker, name, balance, decimals, logo }) => {
+              const totalBalance = (BigInt(balance.balance) + BigInt(balance.lockedBalance)).toString()
+
+              // TODO: Use produceZeros from js-sdk
+              const trailingZeros = '0'.repeat(NUM_OF_ZEROS_IN_QUINTILLION - decimals)
+
+              console.log('logo', logo)
 
               return (
                 <TokenItem key={id}>
                   <LeftGroup>
-                    <TokenIcon>{ticker}</TokenIcon>
+                    <TokenIcon>{logo ? <TokenLogo src={logo} alt={`${name} logo`} /> : ticker}</TokenIcon>
                     <TokenName>{name}</TokenName>
                   </LeftGroup>
-                  <TokenAmount token={ticker} value={totalBalance} fadeDecimals />
+                  <TokenAmount token={ticker} value={BigInt(totalBalance + trailingZeros)} fadeDecimals />
                 </TokenItem>
               )
             })}
@@ -137,6 +145,7 @@ const TokenIcon = styled.div`
   width: 45px;
   height: 45px;
   border-radius: 45px;
+  padding: 10px;
   background-color: ${({ theme }) => theme.bg.highlight};
   color: ${({ theme }) => theme.font.contrast};
   display: flex;
@@ -165,4 +174,9 @@ const TokenName = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 250px;
+`
+
+const TokenLogo = styled.img`
+  width: 100%;
+  height: auto;
 `

--- a/packages/extension/src/ui/features/assets/WalletAssetsScreen.tsx
+++ b/packages/extension/src/ui/features/assets/WalletAssetsScreen.tsx
@@ -155,6 +155,7 @@ const TokenIcon = styled.div`
   flex-shrink: 0;
 `
 
+// TODO: Consider merging with TXAmount
 const TokenAmount = styled(Amount)`
   font-weight: 600;
   font-size: 17px;

--- a/packages/extension/src/ui/features/transactions/TransactionItem.tsx
+++ b/packages/extension/src/ui/features/transactions/TransactionItem.tsx
@@ -88,6 +88,7 @@ export const TXDetailsWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 16px;
 `
 
 export const TXTextGroup = styled.div`
@@ -128,4 +129,7 @@ const TransactionWrapper = styled(TXWrapper)<{ highlighted?: boolean }>`
 const TXAmount = styled(Amount)`
   font-weight: 600;
   font-size: 17px;
+  flex-grow: 1;
+  flex-shrink: 0;
+  text-align: right;
 `

--- a/packages/extension/src/ui/services/backgroundAddresses.ts
+++ b/packages/extension/src/ui/services/backgroundAddresses.ts
@@ -52,6 +52,21 @@ export const getBalances = async (addresses: string[]) => {
   return waitForMessage('GET_ADDRESSES_BALANCE_RES')
 }
 
+export const getAddressTokens = async (address: string) => {
+  sendMessage({ type: 'GET_ADDRESS_TOKENS', data: { address } })
+  return waitForMessage('GET_ADDRESS_TOKENS_RES')
+}
+
+export const getAddressTokenBalance = async (address: string, tokenId: string) => {
+  sendMessage({ type: 'GET_ADDRESS_TOKEN_BALANCE', data: { address, tokenId } })
+  return waitForMessage('GET_ADDRESS_TOKEN_BALANCE_RES')
+}
+
+export const getAddressesTokensBalance = async (addresses: string[]) => {
+  sendMessage({ type: 'GET_ADDRESSES_TOKENS_BALANCE', data: { addresses } })
+  return waitForMessage('GET_ADDRESSES_TOKENS_BALANCE_RES')
+}
+
 export const getSeedPhrase = async (): Promise<string> => {
   const { secret, encryptedSecret } = await generateEncryptedSecret()
   sendMessage({

--- a/packages/extension/src/ui/services/backgroundTransactions.ts
+++ b/packages/extension/src/ui/services/backgroundTransactions.ts
@@ -6,6 +6,11 @@ export const getAlephiumTransactions = async (address: string) => {
   return await waitForMessage('GET_TRANSACTIONS_RES')
 }
 
+export const getAddressTokenTransactions = async (address: string, tokenId: string) => {
+  sendMessage({ type: 'GET_ADDRESS_TOKEN_TRANSACTIONS', data: { address, tokenId } })
+  return await waitForMessage('GET_ADDRESS_TOKEN_TRANSACTIONS_RES')
+}
+
 export const executeAlephiumTransaction = async (data: TransactionPayload): Promise<TransactionResult> => {
   sendMessage({ type: 'EXECUTE_TRANSACTION', data })
   const { actionHash } = await waitForMessage('EXECUTE_TRANSACTION_RES')

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@alephium/sdk@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.1.0.tgz"
-  integrity sha512-7+BENuSaN5mZG64Uflp0tPDRbKJkQiZsE40o1vYOmLkveGzgkitLTmvn9JZ/ey+oEt8HMWosl2VWqq4z9E/sLg==
+"@alephium/sdk@0.2.0-rc.0":
+  version "0.2.0-rc.0"
+  resolved "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.2.0-rc.0.tgz"
+  integrity sha512-mWSNqOwBUL6TnfUlNOy9ag/vg1xfBmImIiP7Flgk5rO2M924UcrSlWuJcwQ/UmrEVw13kzlB3BsRNdHvHz5DBw==
   dependencies:
     base-x "^4.0.0"
     bcfg "~0.1.6"
@@ -21,7 +21,7 @@
 
 "@alephium/web3-wallet@0.2.0-rc.33":
   version "0.2.0-rc.33"
-  resolved "https://registry.yarnpkg.com/@alephium/web3-wallet/-/web3-wallet-0.2.0-rc.33.tgz#e7bb6b9c4b35ac7d3dc8e4c693eda4fbb1a1fe63"
+  resolved "https://registry.npmjs.org/@alephium/web3-wallet/-/web3-wallet-0.2.0-rc.33.tgz"
   integrity sha512-oUS3aXoyCjwK1Z2Iiveauy7MASW4LL8bHA9l78L7QOXa/rbX2xvbsCl62J3uRELqhlV2A6Bnkdcp4QiEq3dDUA==
   dependencies:
     "@alephium/web3" "^0.2.0-rc.33"
@@ -34,7 +34,7 @@
 
 "@alephium/web3@0.2.0-rc.33", "@alephium/web3@^0.2.0-rc.33":
   version "0.2.0-rc.33"
-  resolved "https://registry.yarnpkg.com/@alephium/web3/-/web3-0.2.0-rc.33.tgz#4b19b1a88bd8c1d0138b494e020bc39cc05c7b25"
+  resolved "https://registry.npmjs.org/@alephium/web3/-/web3-0.2.0-rc.33.tgz"
   integrity sha512-Lwvi5hieVvarC5IkIpTHutmBuTMhqN4GOx611KMFKJ7AculqFiX+KVn7/STjxVN5uPB93OaooZBpgBT1LM3ytg==
   dependencies:
     base-x "4.0.0"
@@ -2660,7 +2660,7 @@
 
 "@next/swc-darwin-arm64@12.3.1":
   version "12.3.1"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.1.tgz#b105457d6760a7916b27e46c97cb1a40547114ae"
+  resolved "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.1.tgz"
   integrity sha512-hT/EBGNcu0ITiuWDYU9ur57Oa4LybD5DOQp4f22T6zLfpoBMfBibPtR8XktXmOyFHrL/6FC2p9ojdLZhWhvBHg==
 
 "@next/swc-darwin-x64@12.3.1":
@@ -2690,12 +2690,12 @@
 
 "@next/swc-linux-x64-gnu@12.3.1":
   version "12.3.1"
-  resolved "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.1.tgz"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.1.tgz#c66468f5e8181ffb096c537f0dbfb589baa6a9c1"
   integrity sha512-JWEaMyvNrXuM3dyy9Pp5cFPuSSvG82+yABqsWugjWlvfmnlnx9HOQZY23bFq3cNghy5V/t0iPb6cffzRWylgsA==
 
 "@next/swc-linux-x64-musl@12.3.1":
   version "12.3.1"
-  resolved "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.1.tgz"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.1.tgz#c6269f3e96ac0395bc722ad97ce410ea5101d305"
   integrity sha512-xoEWQQ71waWc4BZcOjmatuvPUXKTv6MbIFzpm4LFeCHsg2iwai0ILmNXf81rJR+L1Wb9ifEke2sQpZSPNz1Iyg==
 
 "@next/swc-win32-arm64-msvc@12.3.1":
@@ -5989,12 +5989,12 @@ esbuild-darwin-64@0.15.8:
 
 esbuild-darwin-arm64@0.14.54:
   version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz#3f7cdb78888ee05e488d250a2bdaab1fa671bf73"
+  resolved "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz"
   integrity sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==
 
 esbuild-darwin-arm64@0.15.8:
   version "0.15.8"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.8.tgz#91c110daa46074fdfc18f411247ca0d1228aacc3"
+  resolved "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.8.tgz"
   integrity sha512-8tjEaBgAKnXCkP7bhEJmEqdG9HEV6oLkF36BrMzpfW2rgaw0c48Zrxe+9RlfeGvs6gDF4w+agXyTjikzsS3izw==
 
 esbuild-freebsd-64@0.14.54:
@@ -6029,12 +6029,12 @@ esbuild-linux-32@0.15.8:
 
 esbuild-linux-64@0.14.54:
   version "0.14.54"
-  resolved "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz#de5fdba1c95666cf72369f52b40b03be71226652"
   integrity sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==
 
 esbuild-linux-64@0.15.8:
   version "0.15.8"
-  resolved "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.8.tgz"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.15.8.tgz#8e738c926d145cdd4e9bcb2febc96d89dc27dc09"
   integrity sha512-4HxrsN9eUzJXdVGMTYA5Xler82FuZUu21bXKN42zcLHHNKCAMPUzD62I+GwDhsdgUBAUj0tRXDdsQHgaP6v0HA==
 
 esbuild-linux-arm64@0.14.54:
@@ -6886,7 +6886,7 @@ fs.realpath@^1.0.0:
 
 fsevents@~2.3.2:
   version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:


### PR DESCRIPTION
This PR fetches the token IDs for each of the addresses and then the balance of each of these tokens for each address and displays a summary in the Assets screen.

Since only the token ID is available through the explorer API, the rest of the metadata (ticker, icon, name) still need to be fetched from somewhere (https://github.com/alephium/tokens-meta?).

EDIT: I used a personal repo to fetch some metadata:

<img width="350" src="https://user-images.githubusercontent.com/1579899/195549417-ad24ba1c-e434-475c-bcad-93f1f92cfa94.png" />
