### PR TITLE
Use `cross-env` to fix npm scripts on windows

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -58,11 +58,11 @@
     "ws": "^8.8.1"
   },
   "scripts": {
-    "build": "NODE_ENV=production webpack",
-    "build:sourcemaps": "GEN_SOURCE_MAPS=true yarn build",
+    "build": "cross-env NODE_ENV=production webpack",
+    "build:sourcemaps": "cross-env GEN_SOURCE_MAPS=true yarn build",
     "start": "webpack",
     "dev": "concurrently -k -r \"webpack --color --watch\" \"yarn dev:hot-reload-server\"",
-    "dev:ui": "SHOW_DEV_UI=true yarn dev",
+    "dev:ui": "cross-env SHOW_DEV_UI=true yarn dev",
     "dev:hot-reload-server": "ts-node ./scripts/hot-reload-server.ts",
     "lint": "eslint . --cache --ext .ts,.tsx",
     "test": "vitest run",
@@ -92,6 +92,7 @@
     "bignumber.js": "^9.0.2",
     "buffer": "^6.0.3",
     "colord": "^2.9.2",
+    "cross-env": "^7.0.3",
     "ethers": "^5.5.1",
     "jose": "^4.3.6",
     "lodash-es": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10200,6 +10200,13 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz"
@@ -10207,7 +10214,7 @@ cross-fetch@^3.1.5:
   dependencies:
     node-fetch "2.6.7"
 
-cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
### Issue / feature description

On windows npm scripts failing with:

```
$ NODE_ENV=production webpack
@alephium/extension: 'NODE_ENV' is not recognized as an internal or external command,
```

### Changes

Use `cross-env` to support cross platform env vars in npm scripts

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally
