### PR TITLE
Fix max button when sending token with decimal 0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/*"],
-  "version": "0.7.3",
+  "version": "0.7.4",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "name": "alephium-browser-extension-wallet",
   "repository": "github:alephium/extension-wallet",

--- a/packages/dapp/package.json
+++ b/packages/dapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alephium/dapp",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packages/extension/manifest/v2.json
+++ b/packages/extension/manifest/v2.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/chrome-manifest.json",
   "name": "Alephium Extension Wallet",
   "description": "Alephium's official extension wallet with powerful features and a clean UI.",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "manifest_version": 2,
   "browser_action": {
     "default_icon": {

--- a/packages/extension/manifest/v3.json
+++ b/packages/extension/manifest/v3.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/chrome-manifest.json",
   "name": "Alephium Extension Wallet",
   "description": "Alephium's official extension wallet with powerful features and a clean UI.",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "manifest_version": 3,
   "action": {
     "default_icon": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alephium/extension",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {

--- a/packages/extension/src/ui/features/accountTokens/tokens.service.ts
+++ b/packages/extension/src/ui/features/accountTokens/tokens.service.ts
@@ -24,24 +24,25 @@ const formatTokenBalanceToCharLength =
       const balanceBn = BigNumber.from(balance)
       const balanceFullString = utils.formatUnits(balanceBn, decimals)
       // show max ${length} characters or what's needed to show everything before the decimal point
-      const balanceString = balanceFullString.slice(
-        0,
-        Math.max(length, balanceFullString.indexOf(".")),
-      )
 
-      let cleanedBalanceString = balanceString
+      let result = balanceFullString
       if (decimals > 0) {
+        const balanceString = balanceFullString.slice(
+          0,
+          Math.max(length, balanceFullString.indexOf(".")),
+        )
+
         // make sure seperator is not the last character, if so remove it
         // remove unnecessary 0s from the end, except for ".0"
-        cleanedBalanceString = balanceString
+        result = balanceString
           .replace(/\.$/, "")
           .replace(/0+$/, "")
-        if (cleanedBalanceString.endsWith(".")) {
-          cleanedBalanceString += "0"
+        if (result.endsWith(".")) {
+          result += "0"
         }
       }
 
-      return cleanedBalanceString
+      return result
     }
 
 export const formatTokenBalance = formatTokenBalanceToCharLength(9)

--- a/packages/extension/src/ui/features/accountTokens/tokens.service.ts
+++ b/packages/extension/src/ui/features/accountTokens/tokens.service.ts
@@ -23,20 +23,22 @@ const formatTokenBalanceToCharLength =
     (balance: BigNumberish = 0, decimals = 18): string => {
       const balanceBn = BigNumber.from(balance)
       const balanceFullString = utils.formatUnits(balanceBn, decimals)
-
       // show max ${length} characters or what's needed to show everything before the decimal point
       const balanceString = balanceFullString.slice(
         0,
         Math.max(length, balanceFullString.indexOf(".")),
       )
 
-      // make sure seperator is not the last character, if so remove it
-      // remove unnecessary 0s from the end, except for ".0"
       let cleanedBalanceString = balanceString
-        .replace(/\.$/, "")
-        .replace(/0+$/, "")
-      if (cleanedBalanceString.endsWith(".")) {
-        cleanedBalanceString += "0"
+      if (decimals > 0) {
+        // make sure seperator is not the last character, if so remove it
+        // remove unnecessary 0s from the end, except for ".0"
+        cleanedBalanceString = balanceString
+          .replace(/\.$/, "")
+          .replace(/0+$/, "")
+        if (cleanedBalanceString.endsWith(".")) {
+          cleanedBalanceString += "0"
+        }
       }
 
       return cleanedBalanceString

--- a/packages/stack-router/package.json
+++ b/packages/stack-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/stack-router",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "license": "MIT",
   "private": true,
   "files": [

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent-x/storybook",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "devDependencies": {
     "@alephium/extension": "^0.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/ui",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "license": "MIT",
   "private": true,
   "files": [


### PR DESCRIPTION
### Issue / feature description

Fix max button when sending token with decimal 0

### Changes

When clicking max button, clean up balance string only when decimal > 0

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [ ] Tests updated (if needed)
- [ ] All tests are passing locally

### Manual Tests

- [x] Transfer ALPH, Token, and NFT
- [x] Display of Token/NFT metadata
- [x] Works with the simple dApp within the repository (yarn run dev)
- [ ] Ledger support

Please keep your pull request as small as possible. If you need to make multiple changes, please create separate pull requests for each change. Create a draft pull request if you need early feedback. This will mark the pull request as a work in progress and prevent it from being reviewed or merged until you are ready.

Please move drafts to the ready for review (regular PR) when you are ready to start the review process and other developers will pick it up from there.
