### PR TITLE
Do not display hide token for NFT page

### DIFF
--- a/packages/extension/src/ui/features/accountNfts/SendNftScreen.tsx
+++ b/packages/extension/src/ui/features/accountNfts/SendNftScreen.tsx
@@ -220,7 +220,7 @@ export const SendNftScreen: FC = () => {
       <NavigationContainer
         leftButton={<BarBackButton />}
         rightButton={
-          <TokenMenuDeprecated tokenId={nft.id} />
+          <TokenMenuDeprecated tokenId={nft.id} canHideToken={false} />
         }
         scrollContent={nft.metadata.name}
       >


### PR DESCRIPTION
After testing it works as intended for https://github.com/alephium/extension-wallet/issues/118
Hide token doesn't make sense for NFT, this PR only removes that.