### PR TITLE
Fix getPreauthorized

### DIFF
--- a/packages/extension/src/shared/preAuthorizations.ts
+++ b/packages/extension/src/shared/preAuthorizations.ts
@@ -81,7 +81,7 @@ export const getPreAuthorizations = () => {
 
 export const getPreAuthorized = async (options: { host: string, networkId?: string, group?: number, keyType?: KeyType }) => {
   const hits = await preAuthorizeStore.get((x) =>
-    matchAuthorizedOptions(x, options)
+    matchAuthorizedOptions(x, { ...options, addressGroup: options.group })
   )
   return hits.length === 0 ? undefined : hits[0]
 }


### PR DESCRIPTION
The naming here is different, it would be better if we could keep the name consistent. There are also `network` and `networkId`.