### PR TITLE
Improve loading NFTs

### DIFF
--- a/packages/extension/src/ui/features/accountActivity/AccountActivityContainer.tsx
+++ b/packages/extension/src/ui/features/accountActivity/AccountActivityContainer.tsx
@@ -8,7 +8,7 @@ import { ErrorBoundaryFallback } from "../../components/ErrorBoundaryFallback"
 import { formatDate } from "../../services/dates"
 import { Account } from "../accounts/Account"
 import { useAccountTransactions } from "../accounts/accountTransactions.state"
-import { useFungibleTokens } from "../accountTokens/tokens.state"
+import { useFungibleTokensWithBalance } from "../accountTokens/tokens.state"
 import { useNetwork } from "../networks/useNetworks"
 import { AccountActivity } from "./AccountActivity"
 import { PendingTransactionsContainer } from "./PendingTransactions"
@@ -56,7 +56,7 @@ const PAGE_SIZE = 10
 export const AccountActivityLoader: FC<AccountActivityContainerProps> = ({
   account,
 }) => {
-  const { tokenDetails: tokens } = useFungibleTokens(account)
+  const { tokenDetails: tokens } = useFungibleTokensWithBalance(account)
 
   const { explorerApiUrl } = useNetwork(account.networkId)
   const { data, setSize } = useAlephiumExplorerAccountTransactionsInfinite(

--- a/packages/extension/src/ui/features/accountActivity/PendingTransactions.tsx
+++ b/packages/extension/src/ui/features/accountActivity/PendingTransactions.tsx
@@ -8,7 +8,7 @@ import { Transaction } from "../../../shared/transactions"
 import { BaseWalletAccount } from "../../../shared/wallet.model"
 import { openExplorerTransaction } from "../../services/blockExplorer.service"
 import { useAccountTransactions } from "../accounts/accountTransactions.state"
-import { useFungibleTokens } from "../accountTokens/tokens.state"
+import { useFungibleTokensWithBalance } from "../accountTokens/tokens.state"
 import { useCurrentNetwork } from "../networks/useNetworks"
 import { ReviewedTransactionListItem } from "./TransactionListItem"
 import { transformReviewedTransaction } from "./transform/transaction/transformTransaction"
@@ -22,7 +22,7 @@ export const PendingTransactionsContainer: FC<
 > = ({ account }) => {
   const network = useCurrentNetwork()
   const { pendingTransactions } = useAccountTransactions(account)
-  const tokensByNetwork = useFungibleTokens(account)
+  const tokensByNetwork = useFungibleTokensWithBalance(account)
 
   return (
     <PendingTransactions

--- a/packages/extension/src/ui/features/accountNfts/AccountCollections.tsx
+++ b/packages/extension/src/ui/features/accountNfts/AccountCollections.tsx
@@ -1,9 +1,7 @@
 import { H4 } from "@argent/ui"
 import { Flex, SimpleGrid } from "@chakra-ui/react"
 import { FC, Suspense } from "react"
-import { useNavigate } from "react-router-dom"
 
-import { routes } from "../../routes"
 import { Account } from "../accounts/Account"
 import { EmptyCollections } from "./EmptyCollections"
 import { NftFigure } from "./NftFigure"
@@ -22,7 +20,6 @@ const Collections: FC<AccountCollectionsProps> = ({
   account,
   navigateToSend = false,
 }) => {
-  const navigate = useNavigate()
   const network = useNetwork(account.networkId)
   const { collectionAndNfts } = useCollectionAndNFTs(network, account)
   const collectionIds = Object.keys(collectionAndNfts)
@@ -41,18 +38,12 @@ const Collections: FC<AccountCollectionsProps> = ({
           mx="3"
         >
           {collectionIds.map((collectionId) => (
-            <NftFigure
-              key={collectionId}
-              onClick={() => {
-                navigate(routes.collectionNfts(collectionId), {
-                  state: { navigateToSend },
-                })
-              }}
-            >
+            <NftFigure key={collectionId}>
               <NftCollectionItem
                 collectionId={collectionId}
                 network={network}
                 account={account}
+                navigateToSend={navigateToSend}
               />
             </NftFigure>
           ))}

--- a/packages/extension/src/ui/features/accountNfts/AccountCollections.tsx
+++ b/packages/extension/src/ui/features/accountNfts/AccountCollections.tsx
@@ -7,10 +7,10 @@ import { routes } from "../../routes"
 import { Account } from "../accounts/Account"
 import { EmptyCollections } from "./EmptyCollections"
 import { NftFigure } from "./NftFigure"
-import { NftItem } from "./NftItem"
-import { useNFTCollections } from "./useNFTCollections"
+import { useCollectionAndNFTs } from "./useNFTCollections"
 import { useNetwork } from "../networks/useNetworks"
 import { Spinner } from "../../components/Spinner"
+import { NftCollectionItem } from "./NftCollectionItem"
 
 interface AccountCollectionsProps {
   account: Account
@@ -24,35 +24,35 @@ const Collections: FC<AccountCollectionsProps> = ({
 }) => {
   const navigate = useNavigate()
   const network = useNetwork(account.networkId)
-  const { collections } = useNFTCollections(network, account)
+  const { collectionAndNfts } = useCollectionAndNFTs(network, account)
+  const collectionIds = Object.keys(collectionAndNfts)
 
   return (
     <>
-      {collections.length === 0 && (
+      {collectionIds.length === 0 && (
         <EmptyCollections networkId={account.networkId} />
       )}
 
-      {collections.length > 0 && (
+      {collectionIds.length > 0 && (
         <SimpleGrid
           gridTemplateColumns="repeat(auto-fill, 158px)"
           gap="3"
           py={4}
           mx="3"
         >
-          {collections.map((collection) => (
+          {collectionIds.map((collectionId) => (
             <NftFigure
-              key={collection.id}
+              key={collectionId}
               onClick={() => {
-                navigate(routes.collectionNfts(collection.id), {
+                navigate(routes.collectionNfts(collectionId), {
                   state: { navigateToSend },
                 })
               }}
             >
-              <NftItem
-                name={collection.metadata.name}
-                thumbnailSrc={collection.metadata.image}
-                total={collection.nfts.length}
-                unverifiedCollection={!collection.verified}
+              <NftCollectionItem
+                collectionId={collectionId}
+                network={network}
+                account={account}
               />
             </NftFigure>
           ))}

--- a/packages/extension/src/ui/features/accountNfts/CollectionNfts.tsx
+++ b/packages/extension/src/ui/features/accountNfts/CollectionNfts.tsx
@@ -7,7 +7,7 @@ import { WarningIconRounded } from "../../components/Icons/WarningIconRounded"
 import { Spinner } from "../../components/Spinner"
 import { routes } from "../../routes"
 import { useSelectedAccount } from "../accounts/accounts.state"
-import { useNonFungibleTokens } from "../accountTokens/tokens.state"
+import { useNonFungibleTokensWithBalance } from "../accountTokens/tokens.state"
 import { useCurrentNetwork } from "../networks/useNetworks"
 import { NftFigure } from "./NftFigure"
 import { NftItem } from "./NftItem"
@@ -17,7 +17,7 @@ export const CollectionNfts: FC = () => {
   const { collectionId } = useParams<{ collectionId: string }>()
   const account = useSelectedAccount()
   const navigate = useNavigate()
-  const unknownTokens = useNonFungibleTokens(account)
+  const unknownTokens = useNonFungibleTokensWithBalance(account)
   const unknownTokenIds = unknownTokens.map((t) => t.id)
   const network = useCurrentNetwork()
   const { collection, error } = useNFTCollection(unknownTokenIds, network, collectionId, account)

--- a/packages/extension/src/ui/features/accountNfts/CollectionNfts.tsx
+++ b/packages/extension/src/ui/features/accountNfts/CollectionNfts.tsx
@@ -1,6 +1,6 @@
 import { BarBackButton, H1, H4, H6, NavigationContainer } from "@argent/ui"
-import { Tooltip, Flex, Image, SimpleGrid } from "@chakra-ui/react"
-import { FC } from "react"
+import { Tooltip, Flex, Image, SimpleGrid, Spinner as Loading } from "@chakra-ui/react"
+import { FC, Suspense } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { WarningIconRounded } from "../../components/Icons/WarningIconRounded"
 
@@ -103,12 +103,18 @@ export const CollectionNfts: FC = () => {
                   navigate(routes.sendNft(collectionId, nftId))
                 }
               >
-                <Nft
-                  collectionId={collectionId}
-                  nftId={nftId}
-                  network={network}
-                  account={account}
-                />
+                <Suspense fallback={
+                  <Flex w="142px" h="142px" justifyContent="center" alignItems="center">
+                    <Loading />
+                  </Flex>}
+                >
+                  <Nft
+                    collectionId={collectionId}
+                    nftId={nftId}
+                    network={network}
+                    account={account}
+                  />
+                </Suspense>
               </NftFigure>
             ))}
           </SimpleGrid>

--- a/packages/extension/src/ui/features/accountNfts/CollectionNfts.tsx
+++ b/packages/extension/src/ui/features/accountNfts/CollectionNfts.tsx
@@ -7,20 +7,17 @@ import { WarningIconRounded } from "../../components/Icons/WarningIconRounded"
 import { Spinner } from "../../components/Spinner"
 import { routes } from "../../routes"
 import { useSelectedAccount } from "../accounts/accounts.state"
-import { useNonFungibleTokensWithBalance } from "../accountTokens/tokens.state"
 import { useCurrentNetwork } from "../networks/useNetworks"
+import { Nft } from "./NFT"
 import { NftFigure } from "./NftFigure"
-import { NftItem } from "./NftItem"
 import { useNFTCollection } from "./useNFTCollections"
 
 export const CollectionNfts: FC = () => {
   const { collectionId } = useParams<{ collectionId: string }>()
   const account = useSelectedAccount()
   const navigate = useNavigate()
-  const unknownTokens = useNonFungibleTokensWithBalance(account)
-  const unknownTokenIds = unknownTokens.map((t) => t.id)
   const network = useCurrentNetwork()
-  const { collection, error } = useNFTCollection(unknownTokenIds, network, collectionId, account)
+  const { collection, error } = useNFTCollection(network, collectionId, account)
 
   if (!collectionId) {
     return <></>
@@ -99,19 +96,18 @@ export const CollectionNfts: FC = () => {
             mx="3"
             py={6}
           >
-            {collection.nfts.map((nft) => (
+            {collection.nftIds.map((nftId) => (
               <NftFigure
-                key={`${nft.collectionId}-${nft.id}`}
+                key={`${collectionId}-${nftId}`}
                 onClick={() =>
-                  navigate(routes.sendNft(nft.collectionId, nft.id))
+                  navigate(routes.sendNft(collectionId, nftId))
                 }
               >
-                <NftItem
-                  thumbnailSrc={nft.metadata.image || ""}
-                  name={
-                    nft.metadata.name ||
-                    "Untitled"
-                  }
+                <Nft
+                  collectionId={collectionId}
+                  nftId={nftId}
+                  network={network}
+                  account={account}
                 />
               </NftFigure>
             ))}

--- a/packages/extension/src/ui/features/accountNfts/CollectionNfts.tsx
+++ b/packages/extension/src/ui/features/accountNfts/CollectionNfts.tsx
@@ -1,5 +1,6 @@
 import { BarBackButton, H1, H4, H6, NavigationContainer } from "@argent/ui"
 import { Tooltip, Flex, Image, SimpleGrid, Spinner as Loading } from "@chakra-ui/react"
+import { ErrorBoundary } from "@sentry/react"
 import { FC, Suspense } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { WarningIconRounded } from "../../components/Icons/WarningIconRounded"
@@ -97,24 +98,21 @@ export const CollectionNfts: FC = () => {
             py={6}
           >
             {collection.nftIds.map((nftId) => (
-              <NftFigure
-                key={`${collectionId}-${nftId}`}
-                onClick={() =>
-                  navigate(routes.sendNft(collectionId, nftId))
-                }
-              >
-                <Suspense fallback={
-                  <Flex w="142px" h="142px" justifyContent="center" alignItems="center">
-                    <Loading />
-                  </Flex>}
-                >
-                  <Nft
-                    collectionId={collectionId}
-                    nftId={nftId}
-                    network={network}
-                    account={account}
-                  />
-                </Suspense>
+              <NftFigure key={`${collectionId}-${nftId}`}>
+                <ErrorBoundary fallback={<H4 mt="10" textAlign="center">Deprecated NFT</H4>}>
+                  <Suspense fallback={
+                    <Flex w="142px" h="142px" justifyContent="center" alignItems="center">
+                      <Loading />
+                    </Flex>}
+                  >
+                    <Nft
+                      collectionId={collectionId}
+                      nftId={nftId}
+                      network={network}
+                      account={account}
+                    />
+                  </Suspense>
+                </ErrorBoundary>
               </NftFigure>
             ))}
           </SimpleGrid>

--- a/packages/extension/src/ui/features/accountNfts/NFT.tsx
+++ b/packages/extension/src/ui/features/accountNfts/NFT.tsx
@@ -4,6 +4,8 @@ import { Account } from "../accounts/Account"
 import { NftItem } from "./NftItem"
 import { useNFT } from "./useNfts"
 import { Flex, Spinner } from "@chakra-ui/react"
+import { useNavigate } from "react-router-dom"
+import { routes } from "../../routes"
 
 interface NftProps {
   collectionId: string
@@ -13,6 +15,7 @@ interface NftProps {
 }
 
 const Nft: FC<NftProps> = ({ collectionId, nftId, account, network }) => {
+  const navigate = useNavigate()
   const { nft } = useNFT(network, collectionId, nftId, account)
   if (nft === undefined) {
     return (
@@ -22,11 +25,9 @@ const Nft: FC<NftProps> = ({ collectionId, nftId, account, network }) => {
     )
   }
   return <NftItem
+    onClick={() => navigate(routes.sendNft(collectionId, nftId))}
     thumbnailSrc={nft.metadata.image || ""}
-    name={
-      nft.metadata.name ||
-      "Untitled"
-    }
+    name={nft.metadata.name || "Untitled"}
   />
 }
 

--- a/packages/extension/src/ui/features/accountNfts/NFT.tsx
+++ b/packages/extension/src/ui/features/accountNfts/NFT.tsx
@@ -1,0 +1,33 @@
+import { FC } from "react"
+import { Network } from "../../../shared/network"
+import { Account } from "../accounts/Account"
+import { NftItem } from "./NftItem"
+import { useNFT } from "./useNfts"
+import { Flex, Spinner } from "@chakra-ui/react"
+
+interface NftProps {
+  collectionId: string
+  nftId: string
+  network: Network
+  account?: Account
+}
+
+const Nft: FC<NftProps> = ({ collectionId, nftId, account, network }) => {
+  const { nft } = useNFT(network, collectionId, nftId, account)
+  if (nft === undefined) {
+    return (
+      <Flex w="142px" h="142px" justifyContent="center" alignItems="center">
+        <Spinner />
+      </Flex>
+    )
+  }
+  return <NftItem
+    thumbnailSrc={nft.metadata.image || ""}
+    name={
+      nft.metadata.name ||
+      "Untitled"
+    }
+  />
+}
+
+export { Nft }

--- a/packages/extension/src/ui/features/accountNfts/NftCollectionItem.tsx
+++ b/packages/extension/src/ui/features/accountNfts/NftCollectionItem.tsx
@@ -1,0 +1,31 @@
+import { FC } from "react"
+import { Network } from "../../../shared/network"
+import { Account } from "../accounts/Account"
+import { NftItem } from "./NftItem"
+import { useNFTCollection } from "./useNFTCollections"
+import { Flex, Spinner } from "@chakra-ui/react"
+
+interface NftCollectionItemProps {
+  collectionId: string
+  network: Network
+  account: Account
+}
+
+const NftCollectionItem: FC<NftCollectionItemProps> = ({ network, collectionId, account }) => {
+  const { collection } = useNFTCollection(network, collectionId, account)
+  if (collection === undefined) {
+    return (
+      <Flex w="142px" h="142px" justifyContent="center" alignItems="center">
+        <Spinner />
+      </Flex>
+    )
+  }
+  return <NftItem
+    name={collection.metadata.name}
+    thumbnailSrc={collection.metadata.image}
+    total={collection.nftIds.length}
+    unverifiedCollection={!collection.verified}
+  />
+}
+
+export { NftCollectionItem }

--- a/packages/extension/src/ui/features/accountNfts/NftCollectionItem.tsx
+++ b/packages/extension/src/ui/features/accountNfts/NftCollectionItem.tsx
@@ -4,14 +4,18 @@ import { Account } from "../accounts/Account"
 import { NftItem } from "./NftItem"
 import { useNFTCollection } from "./useNFTCollections"
 import { Flex, Spinner } from "@chakra-ui/react"
+import { useNavigate } from "react-router-dom"
+import { routes } from "../../routes"
 
 interface NftCollectionItemProps {
   collectionId: string
   network: Network
   account: Account
+  navigateToSend: boolean
 }
 
-const NftCollectionItem: FC<NftCollectionItemProps> = ({ network, collectionId, account }) => {
+const NftCollectionItem: FC<NftCollectionItemProps> = ({ network, collectionId, account, navigateToSend }) => {
+  const navigate = useNavigate()
   const { collection } = useNFTCollection(network, collectionId, account)
   if (collection === undefined) {
     return (
@@ -21,6 +25,11 @@ const NftCollectionItem: FC<NftCollectionItemProps> = ({ network, collectionId, 
     )
   }
   return <NftItem
+    onClick={() => {
+      navigate(routes.collectionNfts(collectionId), {
+        state: { navigateToSend },
+      })
+    }}
     name={collection.metadata.name}
     thumbnailSrc={collection.metadata.image}
     total={collection.nftIds.length}

--- a/packages/extension/src/ui/features/accountNfts/NftFigure.tsx
+++ b/packages/extension/src/ui/features/accountNfts/NftFigure.tsx
@@ -2,11 +2,10 @@ import { Box } from "@chakra-ui/react"
 import { FC, ReactNode } from "react"
 
 interface NftFigureProps {
-  onClick: () => void
   children: ReactNode
 }
 
-const NftFigure: FC<NftFigureProps> = ({ onClick, children }) => (
+const NftFigure: FC<NftFigureProps> = ({ children }) => (
   <Box
     w="160px"
     h="192px"
@@ -19,7 +18,6 @@ const NftFigure: FC<NftFigureProps> = ({ onClick, children }) => (
     data-group
     borderRadius="lg"
     p="2"
-    onClick={onClick}
     _hover={{ backgroundColor: "neutrals.700" }}
   >
     {children}

--- a/packages/extension/src/ui/features/accountNfts/NftItem.tsx
+++ b/packages/extension/src/ui/features/accountNfts/NftItem.tsx
@@ -7,13 +7,14 @@ import { NftThumbnailImage } from "./NftThumbnailImage"
 interface NftItemProps {
   name: string
   thumbnailSrc: string
+  onClick: () => void
   logoSrc?: string
   total?: number
   unverifiedCollection?: boolean
 }
 
-const NftItem: FC<NftItemProps> = ({ logoSrc, name, thumbnailSrc, total, unverifiedCollection }) => (
-  <Box as="figure" role="group">
+const NftItem: FC<NftItemProps> = ({ logoSrc, name, thumbnailSrc, onClick, total, unverifiedCollection }) => (
+  <Box as="figure" role="group" onClick={onClick}>
     <Box
       position="relative"
       transition={"transform 0.2s ease-in-out"}

--- a/packages/extension/src/ui/features/accountNfts/NftScreen.tsx
+++ b/packages/extension/src/ui/features/accountNfts/NftScreen.tsx
@@ -26,11 +26,11 @@ import { Navigate, useNavigate, useParams } from "react-router-dom"
 import { Schema, object } from "yup"
 
 import { routes } from "../../routes"
-import { addressSchema, isEqualAddress } from "../../services/addresses"
+import { addressSchema } from "../../services/addresses"
 import { useSelectedAccount } from "../accounts/accounts.state"
 import { TokenMenu } from "../accountTokens/TokenMenu"
 import { useCurrentNetwork } from "../networks/useNetworks"
-import { useNFTCollection } from "./useNFTCollections"
+import { useNFT } from "./useNfts"
 const { SwapIcon } = icons
 
 const { SendIcon } = icons
@@ -47,22 +47,7 @@ export const NftScreen: FC = () => {
   const { contractAddress, tokenId } = useParams()
   const account = useSelectedAccount()
   const network = useCurrentNetwork()
-
-  const { collection } = useNFTCollection(
-    tokenId && [tokenId] || [],
-    network,
-    contractAddress,
-    account
-  )
-
-  const nft = collection && collection.nfts
-    .filter(Boolean)
-    .find(
-      ({ collectionId, id }) =>
-        contractAddress &&
-        isEqualAddress(collectionId, contractAddress) &&
-        id === tokenId,
-    )
+  const { nft } = useNFT(network, contractAddress, tokenId, account)
 
   if (!account || !contractAddress || !tokenId) {
     return <Navigate to={routes.accounts()} />

--- a/packages/extension/src/ui/features/accountNfts/SendNftScreen.tsx
+++ b/packages/extension/src/ui/features/accountNfts/SendNftScreen.tsx
@@ -1,5 +1,5 @@
 import { BarBackButton, NavigationContainer } from "@argent/ui"
-import { FC, useCallback, useMemo, useRef, useState } from "react"
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useForm } from "react-hook-form"
 import { Navigate, useNavigate, useParams } from "react-router-dom"
 import styled from "styled-components"
@@ -90,7 +90,8 @@ export const SendNftScreen: FC = () => {
   const network = useCurrentNetwork()
 
   console.log("tokenId", nftId)
-  const { nft } = useNFT(network, nftCollectionId, nftId, account)
+  const { nft, mutate } = useNFT(network, nftCollectionId, nftId, account)
+  useEffect(() => { mutate() }, [mutate])
 
   const resolver = useYupValidationResolver(SendNftSchema)
 

--- a/packages/extension/src/ui/features/accountNfts/SendNftScreen.tsx
+++ b/packages/extension/src/ui/features/accountNfts/SendNftScreen.tsx
@@ -46,9 +46,9 @@ import {
 import { TokenMenuDeprecated } from "../accountTokens/TokenMenuDeprecated"
 import { useCurrentNetwork } from "../networks/useNetworks"
 import { useYupValidationResolver } from "../settings/useYupValidationResolver"
-import { useNFTCollection } from "./useNFTCollections"
 import { Destination, DUST_AMOUNT } from "@alephium/web3"
 import { sendTransferTransaction } from "../../services/transactions"
+import { useNFT } from "./useNfts"
 
 export const NftImageContainer = styled.div`
   width: 96px;
@@ -90,17 +90,7 @@ export const SendNftScreen: FC = () => {
   const network = useCurrentNetwork()
 
   console.log("tokenId", nftId)
-  const { collection } = useNFTCollection(
-    nftId && [nftId] || [],
-    network,
-    nftCollectionId,
-    account
-  )
-
-  const nft = collection && collection.nfts.find(
-    ({ collectionId, id }) =>
-      collectionId === nftCollectionId && id === nftId,
-  )
+  const { nft } = useNFT(network, nftCollectionId, nftId, account)
 
   const resolver = useYupValidationResolver(SendNftSchema)
 

--- a/packages/extension/src/ui/features/accountNfts/alephium-nft.model.ts
+++ b/packages/extension/src/ui/features/accountNfts/alephium-nft.model.ts
@@ -33,11 +33,11 @@ export interface NFT {
 export interface NFTCollection {
   id: string
   metadata: NFTCollectionMeta
-  nfts: NFT[]
+  nftIds: string[]
   verified: boolean
 }
 
-export type NFTCollections = NFTCollection[]
+export type CollectionAndNFTMap = Record<string, string[]>
 
 export const whitelistedCollection: Record<string, string[]> = whitelistedCollectionFromTokenList
   .reduce((acc, collections) => {

--- a/packages/extension/src/ui/features/accountNfts/alephium-nft.service.ts
+++ b/packages/extension/src/ui/features/accountNfts/alephium-nft.service.ts
@@ -1,17 +1,17 @@
-import { whitelistedCollection, NFT } from "./alephium-nft.model"
+import { whitelistedCollection, NFT, CollectionAndNFTMap } from "./alephium-nft.model"
 import { NFTCollection } from "./alephium-nft.model"
 import { Network } from "../../../shared/network"
 import { addressFromContractId, binToHex, contractIdFromAddress, ExplorerProvider, NodeProvider } from "@alephium/web3"
 import { fetchImmutable } from "../../../shared/utils/fetchImmutable"
 
-export const fetchNFTCollections = async (
+export const fetchCollectionAndNfts = async (
   nonFungibleTokenIds: string[],
   network: Network
-): Promise<NFTCollection[]> => {
+): Promise<CollectionAndNFTMap> => {
   const explorerProvider = new ExplorerProvider(network.explorerApiUrl)
   const nodeProvider = new NodeProvider(network.nodeUrl)
 
-  const parentAndTokenIds: [string, string][] = []
+  const parentAndTokenIds: CollectionAndNFTMap = {}
   for (const tokenId of nonFungibleTokenIds) {
     try {
       const result = await fetchImmutable(`${tokenId}-parent`, () => explorerProvider.contracts.getContractsContractParent(addressFromContractId(tokenId)))
@@ -21,125 +21,55 @@ export const fetchNFTCollections = async (
 
         // Guess if parent implements the NFT collection standard interface
         if (isFollowNFTCollectionStd) {
-          parentAndTokenIds.push([parentContractId, tokenId])
+          if (parentAndTokenIds[parentContractId]) {
+            parentAndTokenIds[parentContractId].push(tokenId)
+          } else {
+            parentAndTokenIds[parentContractId] = [tokenId]
+          }
         }
       }
     } catch (e) {
       console.error("Error fetching parent for token id", e)
     }
   }
-
-  const tokenIdsByNFTCollections = parentAndTokenIds.reduce((acc, parentAndTokenId) => {
-    const [parent, tokenId] = parentAndTokenId
-    if (!!parent && !!tokenId) {
-      if (acc[parent]) {
-        acc[parent].push(tokenId)
-      } else {
-        acc[parent] = [tokenId]
-      }
-    }
-
-    return acc
-  }, {} as Record<string, string[]>)
-
-  const collections: NFTCollection[] = []
-  for (const collectionId in tokenIdsByNFTCollections) {
-    try {
-      const nftIds = tokenIdsByNFTCollections[collectionId]
-      const collectionMetadata = await getCollectionMetadata(collectionId, nodeProvider)
-      const nfts: NFT[] = await getNFTs(collectionId, nftIds, nodeProvider)
-      collections.push({
-        id: collectionId,
-        metadata: collectionMetadata,
-        nfts: nfts,
-        verified: isWhitelistedCollection(collectionId, network.id)
-      })
-    } catch (e) {
-      console.log(`Error fetching NFT collection ${collectionId}`, e)
-    }
-  }
-
-  return collections
-}
-
-async function getNftIds(
-  collectionAddress: string,
-  tokenIds: string[],
-  explorerProvider: ExplorerProvider,
-  finalNftIds: string[] = [],
-  page = 1
-): Promise<string[]> {
-  const pageSize = 100
-  const { subContracts } = await explorerProvider.contracts.getContractsContractSubContracts(collectionAddress, { page, limit: pageSize })
-
-  if (!subContracts) {
-    return finalNftIds
-  }
-
-  const nftIds = tokenIds.filter((tokenId) => subContracts.includes(addressFromContractId(tokenId)))
-  if (nftIds.length > 0) {
-    finalNftIds.push(...nftIds)
-  }
-
-  if (subContracts.length < pageSize) {
-    return finalNftIds
-  } else {
-    return getNftIds(collectionAddress, tokenIds, explorerProvider, finalNftIds, page + 1)
-  }
+  return parentAndTokenIds
 }
 
 export const fetchNFTCollection = async (
   collectionId: string,
-  tokenIds: string[],
-  network: Network,
+  nftIds: string[],
+  network: Network
 ): Promise<NFTCollection | undefined> => {
   try {
-    const explorerProvider = new ExplorerProvider(network.explorerApiUrl)
     const nodeProvider = new NodeProvider(network.nodeUrl)
-    const collectionAddress = addressFromContractId(collectionId)
-    const nftIds = await getNftIds(collectionAddress, tokenIds, explorerProvider)
-
-    if (!nftIds) {
-      return undefined
-    }
-
     const collectionMetadata = await getCollectionMetadata(collectionId, nodeProvider)
-    const nfts: NFT[] = await getNFTs(collectionId, nftIds, nodeProvider)
     return {
       id: collectionId,
       metadata: collectionMetadata,
-      nfts: nfts,
+      nftIds: nftIds,
       verified: isWhitelistedCollection(collectionId, network.id)
     }
-  } catch (e) {
-    console.log(`Error fetching NFT collection ${collectionId}`, e)
+  } catch (error) {
+    console.log(`Error fetching NFT collection ${collectionId}, error: ${error}`)
     return undefined
   }
 }
 
-async function getNFTs(
-  collectionId: string,
-  nftIds: string[],
-  nodeProvider: NodeProvider
-): Promise<NFT[]> {
-  const nfts: NFT[] = [];
-
-  for (const nftId of nftIds) {
-    try {
-      const nftMetadata = await nodeProvider.fetchNFTMetaData(nftId)
-      const metadataResponse = await fetch(nftMetadata.tokenUri)
-      const metadata = await metadataResponse.json()
-      nfts.push({
-        id: nftId,
-        collectionId: collectionId,
-        metadata: metadata
-      })
-    } catch (e) {
-      console.error("Error fetching NFT", nftId)
+export async function getNFT(collectionId: string, nftId: string, network: Network): Promise<NFT | undefined> {
+  try {
+    const nodeProvider = new NodeProvider(network.nodeUrl)
+    const nftMetadata = await nodeProvider.fetchNFTMetaData(nftId)
+    const metadataResponse = await fetch(nftMetadata.tokenUri)
+    const metadata = await metadataResponse.json()
+    return {
+      id: nftId,
+      collectionId: collectionId,
+      metadata: metadata
     }
+  } catch (error) {
+    console.log(`Error fetching NFT ${nftId}, error: ${error}`)
+    return undefined
   }
-
-  return nfts
 }
 
 async function getCollectionMetadata(

--- a/packages/extension/src/ui/features/accountNfts/alephium-nft.service.ts
+++ b/packages/extension/src/ui/features/accountNfts/alephium-nft.service.ts
@@ -29,7 +29,7 @@ export const fetchCollectionAndNfts = async (
         }
       }
     } catch (e) {
-      console.error("Error fetching parent for token id", e)
+      console.error(`Error fetching parent for collection id for NFT ${tokenId}`, e)
     }
   }
   return parentAndTokenIds

--- a/packages/extension/src/ui/features/accountNfts/alephium-nft.service.ts
+++ b/packages/extension/src/ui/features/accountNfts/alephium-nft.service.ts
@@ -67,6 +67,9 @@ export async function getNFT(collectionId: string, nftId: string, network: Netwo
       metadata: metadata
     }
   } catch (error) {
+    if (error instanceof Error && error.message.includes('Deprecated NFT contract')) {
+      throw error
+    }
     console.log(`Error fetching NFT ${nftId}, error: ${error}`)
     return undefined
   }

--- a/packages/extension/src/ui/features/accountNfts/laggy.tsx
+++ b/packages/extension/src/ui/features/accountNfts/laggy.tsx
@@ -1,0 +1,29 @@
+import { SWRHook } from "swr"
+import { useRef, useEffect, useCallback } from 'react'
+
+// from: https://swr.vercel.app/docs/middleware#keep-previous-result
+export function laggy(useSWRNext: SWRHook) {
+  return (key: any, fetcher: any, config: any) => {
+    const laggyDataRef = useRef()
+    const swr = useSWRNext(key, fetcher, config)
+
+    useEffect(() => {
+      if (swr.data !== undefined) {
+        laggyDataRef.current = swr.data
+      }
+    }, [swr.data])
+
+    const resetLaggy = useCallback(() => {
+      laggyDataRef.current = undefined
+    }, [])
+
+    const dataOrLaggyData = swr.data === undefined ? laggyDataRef.current : swr.data
+    const isLagging = swr.data === undefined && laggyDataRef.current !== undefined
+
+    return Object.assign({}, swr, {
+      data: dataOrLaggyData,
+      isLagging,
+      resetLaggy,
+    })
+  }
+}

--- a/packages/extension/src/ui/features/accountNfts/useNFTCollections.ts
+++ b/packages/extension/src/ui/features/accountNfts/useNFTCollections.ts
@@ -21,8 +21,8 @@ export const useCollectionAndNFTs = (
     account && nonFungibleTokenIds.length > 0 && [getAccountIdentifier(account), 'collectionAndNft'],
     () => fetchCollectionAndNfts(nonFungibleTokenIds, network),
     {
-      refreshInterval: 30000,
       ...config,
+      refreshInterval: 30000,
     }
   )
 
@@ -41,9 +41,9 @@ export const useNFTCollection = (
     account && collectionId && [getAccountIdentifier(account), collectionId, 'collection'],
     () => collectionId ? fetchNFTCollection(collectionId, nftIds, network) : undefined,
     {
+      ...config,
       refreshInterval: 60e3 /* 1 minute */,
       use: [laggy],
-      ...config,
     },
   )
   return { collection, ...rest }

--- a/packages/extension/src/ui/features/accountNfts/useNFTCollections.ts
+++ b/packages/extension/src/ui/features/accountNfts/useNFTCollections.ts
@@ -7,6 +7,7 @@ import { SWRConfigCommon } from "../../services/swr"
 import { Network } from "../../../shared/network"
 import { fetchNFTCollection, fetchCollectionAndNfts } from "./alephium-nft.service"
 import { useNonFungibleTokensWithBalance } from "../accountTokens/tokens.state"
+import { laggy } from "./laggy"
 
 export const useCollectionAndNFTs = (
   network: Network,
@@ -20,8 +21,7 @@ export const useCollectionAndNFTs = (
     account && nonFungibleTokenIds.length > 0 && [getAccountIdentifier(account), 'collectionAndNft'],
     () => fetchCollectionAndNfts(nonFungibleTokenIds, network),
     {
-      refreshInterval: 60e3 /* 1 minute */,
-      suspense: true,
+      refreshInterval: 30000,
       ...config,
     }
   )
@@ -42,7 +42,7 @@ export const useNFTCollection = (
     () => collectionId ? fetchNFTCollection(collectionId, nftIds, network) : undefined,
     {
       refreshInterval: 60e3 /* 1 minute */,
-      suspense: true,
+      use: [laggy],
       ...config,
     },
   )

--- a/packages/extension/src/ui/features/accountNfts/useNFTCollections.ts
+++ b/packages/extension/src/ui/features/accountNfts/useNFTCollections.ts
@@ -6,14 +6,14 @@ import { SWRConfigCommon } from "../../services/swr"
 
 import { Network } from "../../../shared/network"
 import { fetchNFTCollections, fetchNFTCollection } from "./alephium-nft.service"
-import { useNonFungibleTokens } from "../accountTokens/tokens.state"
+import { useNonFungibleTokensWithBalance } from "../accountTokens/tokens.state"
 
 export const useNFTCollections = (
   network: Network,
   account?: BaseWalletAccount,
   config?: SWRConfigCommon,
 ) => {
-  const nonFungibleTokens = useNonFungibleTokens(account)
+  const nonFungibleTokens = useNonFungibleTokensWithBalance(account)
   const nonFungibleTokenIds = nonFungibleTokens.map((t) => t.id)
 
   const { data: collections, ...rest } = useSWR(

--- a/packages/extension/src/ui/features/accountNfts/useNFTCollections.ts
+++ b/packages/extension/src/ui/features/accountNfts/useNFTCollections.ts
@@ -5,10 +5,10 @@ import { getAccountIdentifier } from "../../../shared/wallet.service"
 import { SWRConfigCommon } from "../../services/swr"
 
 import { Network } from "../../../shared/network"
-import { fetchNFTCollections, fetchNFTCollection } from "./alephium-nft.service"
+import { fetchNFTCollection, fetchCollectionAndNfts } from "./alephium-nft.service"
 import { useNonFungibleTokensWithBalance } from "../accountTokens/tokens.state"
 
-export const useNFTCollections = (
+export const useCollectionAndNFTs = (
   network: Network,
   account?: BaseWalletAccount,
   config?: SWRConfigCommon,
@@ -16,54 +16,35 @@ export const useNFTCollections = (
   const nonFungibleTokens = useNonFungibleTokensWithBalance(account)
   const nonFungibleTokenIds = nonFungibleTokens.map((t) => t.id)
 
-  const { data: collections, ...rest } = useSWR(
-    account &&
-    nonFungibleTokenIds.length > 0 &&
-    [
-      getAccountIdentifier(account),
-      nonFungibleTokenIds,
-      "collections",
-    ],
-    () => fetchNFTCollections(nonFungibleTokenIds, network),
+  const { data: collectionAndNfts, ...rest } = useSWR(
+    account && nonFungibleTokenIds.length > 0 && [getAccountIdentifier(account), 'collectionAndNft'],
+    () => fetchCollectionAndNfts(nonFungibleTokenIds, network),
     {
       refreshInterval: 60e3 /* 1 minute */,
       suspense: true,
       ...config,
-    },
+    }
   )
 
-  return { collections: collections || [], ...rest }
+  return { collectionAndNfts: collectionAndNfts || {}, ...rest }
 }
 
 export const useNFTCollection = (
-  tokenIds: string[],
   network: Network,
   collectionId?: string,
   account?: BaseWalletAccount,
   config?: SWRConfigCommon,
 ) => {
+  const { collectionAndNfts } = useCollectionAndNFTs(network, account, config)
+  const nftIds = collectionId === undefined ? [] : (collectionAndNfts[collectionId] ?? [])
   const { data: collection, ...rest } = useSWR(
-    collectionId &&
-    tokenIds.length > 0 &&
-    account && [
-      getAccountIdentifier(account),
-      collectionId,
-      tokenIds,
-      "collection",
-    ],
-    async () => {
-      if (collectionId) {
-        return await fetchNFTCollection(collectionId, tokenIds, network)
-      } else {
-        return Promise.resolve(undefined)
-      }
-    },
+    account && collectionId && [getAccountIdentifier(account), collectionId, 'collection'],
+    () => collectionId ? fetchNFTCollection(collectionId, nftIds, network) : undefined,
     {
       refreshInterval: 60e3 /* 1 minute */,
       suspense: true,
       ...config,
     },
   )
-
   return { collection, ...rest }
 }

--- a/packages/extension/src/ui/features/accountNfts/useNfts.ts
+++ b/packages/extension/src/ui/features/accountNfts/useNfts.ts
@@ -4,6 +4,7 @@ import { BaseWalletAccount } from "../../../shared/wallet.model"
 import { getAccountIdentifier } from "../../../shared/wallet.service"
 import { SWRConfigCommon } from "../../services/swr"
 import { getNFT } from "./alephium-nft.service"
+import { laggy } from "./laggy"
 
 export const useNFT = (
   network: Network,
@@ -17,6 +18,9 @@ export const useNFT = (
     () => (collectionId && nftId) ? getNFT(collectionId, nftId, network) : undefined,
     {
       refreshInterval: 60e3 /* 1 minute */,
+      revalidateOnFocus: false,
+      revalidateOnMount: false,
+      use: [laggy],
       suspense: true,
       ...config,
     },

--- a/packages/extension/src/ui/features/accountNfts/useNfts.ts
+++ b/packages/extension/src/ui/features/accountNfts/useNfts.ts
@@ -17,7 +17,6 @@ export const useNFT = (
     account && collectionId && nftId && [getAccountIdentifier(account), collectionId, nftId, 'nft'],
     () => (collectionId && nftId) ? getNFT(collectionId, nftId, network) : undefined,
     {
-      refreshInterval: 60e3 /* 1 minute */,
       revalidateOnFocus: false,
       revalidateOnMount: false,
       use: [laggy],

--- a/packages/extension/src/ui/features/accountNfts/useNfts.ts
+++ b/packages/extension/src/ui/features/accountNfts/useNfts.ts
@@ -17,11 +17,11 @@ export const useNFT = (
     account && collectionId && nftId && [getAccountIdentifier(account), collectionId, nftId, 'nft'],
     () => (collectionId && nftId) ? getNFT(collectionId, nftId, network) : undefined,
     {
+      ...config,
       revalidateOnFocus: false,
       revalidateOnMount: false,
       use: [laggy],
       suspense: true,
-      ...config,
     },
   )
   return { nft, ...rest }

--- a/packages/extension/src/ui/features/accountNfts/useNfts.ts
+++ b/packages/extension/src/ui/features/accountNfts/useNfts.ts
@@ -1,24 +1,25 @@
 import useSWR from "swr"
-
+import { Network } from "../../../shared/network"
 import { BaseWalletAccount } from "../../../shared/wallet.model"
 import { getAccountIdentifier } from "../../../shared/wallet.service"
-import { isEqualAddress } from "../../services/addresses"
 import { SWRConfigCommon } from "../../services/swr"
-import { AspectNft } from "./aspect.model"
+import { getNFT } from "./alephium-nft.service"
 
-interface IGetNft {
-  nfts?: AspectNft[]
-  contractAddress: string
-  tokenId: string
-}
-
-export const getNft = ({ nfts, contractAddress, tokenId }: IGetNft) => {
-  if (!nfts) {
-    return
-  }
-  const nft = nfts.find(
-    ({ contract_address, token_id }) =>
-      isEqualAddress(contract_address, contractAddress) && token_id === tokenId,
+export const useNFT = (
+  network: Network,
+  collectionId?: string,
+  nftId?: string,
+  account?: BaseWalletAccount,
+  config?: SWRConfigCommon,
+) => {
+  const { data: nft, ...rest } = useSWR(
+    account && collectionId && nftId && [getAccountIdentifier(account), collectionId, nftId, 'nft'],
+    () => (collectionId && nftId) ? getNFT(collectionId, nftId, network) : undefined,
+    {
+      refreshInterval: 60e3 /* 1 minute */,
+      suspense: true,
+      ...config,
+    },
   )
-  return nft
+  return { nft, ...rest }
 }

--- a/packages/extension/src/ui/features/accountTokens/AccountTokensButtons.tsx
+++ b/packages/extension/src/ui/features/accountTokens/AccountTokensButtons.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from "react-router-dom"
 import { useAppState } from "../../app.state"
 import { routes } from "../../routes"
 import { Account } from "../accounts/Account"
-import { useNetworkFeeToken, useFungibleTokens } from "./tokens.state"
+import { useNetworkFeeToken, useFungibleTokensWithBalance } from "./tokens.state"
 
 const { AddIcon, SendIcon } = icons
 
@@ -21,7 +21,7 @@ export const AccountTokensButtons: FC<AccountTokensButtonsProps> = ({
   const { switcherNetworkId } = useAppState()
 
   const sendToken = useNetworkFeeToken(switcherNetworkId)
-  const { tokenDetails, tokenDetailsIsInitialising } = useFungibleTokens(account)
+  const { tokenDetails, tokenDetailsIsInitialising } = useFungibleTokensWithBalance(account)
 
   const hasNonZeroBalance = useMemo(() => {
     return tokenDetails.some(({ balance }) => balance?.gt(0))

--- a/packages/extension/src/ui/features/accountTokens/AccountTokensHeader.tsx
+++ b/packages/extension/src/ui/features/accountTokens/AccountTokensHeader.tsx
@@ -7,7 +7,7 @@ import { BaseWalletAccount } from "../../../shared/wallet.model"
 import { AddressCopyButtonMain } from "../../components/AddressCopyButton"
 import { AccountStatus } from "../accounts/accounts.service"
 import { useSumTokenBalancesToCurrencyValue } from "./tokenPriceHooks"
-import { useFungibleTokens } from "./tokens.state"
+import { useFungibleTokensWithBalance } from "./tokens.state"
 
 interface AccountSubheaderProps {
   status: AccountStatus
@@ -20,7 +20,7 @@ export const AccountTokensHeader: FC<AccountSubheaderProps> = ({
   account,
   accountName
 }) => {
-  const { tokenDetails } = useFungibleTokens(account)
+  const { tokenDetails } = useFungibleTokensWithBalance(account)
   const sumCurrencyValue = useSumTokenBalancesToCurrencyValue(tokenDetails)
   const accountAddress = account.address
 

--- a/packages/extension/src/ui/features/accountTokens/TokenList.tsx
+++ b/packages/extension/src/ui/features/accountTokens/TokenList.tsx
@@ -9,7 +9,7 @@ import { useSelectedAccount } from "../accounts/accounts.state"
 import { NewTokenButton } from "./NewTokenButton"
 import { TokenListItemVariant } from "./TokenListItem"
 import { TokenListItemContainer } from "./TokenListItemContainer"
-import { useFungibleTokens } from "./tokens.state"
+import { useFungibleTokensWithBalance } from "./tokens.state"
 
 interface TokenListProps {
   tokenList?: Token[]
@@ -28,7 +28,7 @@ export const TokenList: FC<TokenListProps> = ({
 }) => {
   const navigate = useNavigate()
   const account = useSelectedAccount()
-  const tokensForAccount = useFungibleTokens(account)
+  const tokensForAccount = useFungibleTokensWithBalance(account)
   if (!account) {
     return null
   }

--- a/packages/extension/src/ui/features/accountTokens/TokenScreen.tsx
+++ b/packages/extension/src/ui/features/accountTokens/TokenScreen.tsx
@@ -20,7 +20,7 @@ import { TokenIcon } from "./TokenIcon"
 import { TokenMenuDeprecated } from "./TokenMenuDeprecated"
 import { useTokenBalanceToCurrencyValue } from "./tokenPriceHooks"
 import { toTokenView } from "./tokens.service"
-import { useFungibleTokens } from "./tokens.state"
+import { useFungibleTokensWithBalance } from "./tokens.state"
 
 const TokenScreenWrapper = styled(ColumnCenter)`
   width: 100%;
@@ -88,7 +88,7 @@ export const TokenScreen: FC = () => {
   const navigate = useNavigate()
   const { tokenId } = useParams()
   const account = useSelectedAccount()
-  const { tokenDetails, tokenDetailsIsInitialising, isValidating } = useFungibleTokens(account)
+  const { tokenDetails, tokenDetailsIsInitialising, isValidating } = useFungibleTokensWithBalance(account)
   const token = useMemo(
     () => tokenDetails.find(({ id }) => id === tokenId),
     [tokenId, tokenDetails],

--- a/packages/extension/src/ui/features/accountTokens/tokens.state.ts
+++ b/packages/extension/src/ui/features/accountTokens/tokens.state.ts
@@ -332,7 +332,7 @@ async function getBalances(nodeProvider: NodeProvider, address: string): Promise
 async function fetchFungibleTokenFromFullNode(network: Network, tokenId: string): Promise<Token | undefined> {
   const nodeProvider = new NodeProvider(network.nodeUrl)
   try {
-    const tokenType = await nodeProvider.guessStdTokenType(tokenId)
+    const tokenType = await fetchImmutable(`${tokenId}-token-type`, () => nodeProvider.guessStdTokenType(tokenId))
     if (tokenType !== 'fungible') {
       return undefined
     }

--- a/packages/extension/src/ui/features/accountTokens/tokens.state.ts
+++ b/packages/extension/src/ui/features/accountTokens/tokens.state.ts
@@ -18,8 +18,8 @@ import { sortBy } from "lodash"
 import { addTokenToBalances } from "../../../shared/token/balance"
 import { Transaction, compareTransactions } from "../../../shared/transactions"
 
-type UseTokens = UseTokensBase<TokenWithBalance>
-type UseBaseTokens = UseTokensBase<BaseTokenWithBalance>
+type UseTokensWithBalance = UseTokensBase<TokenWithBalance>
+type UseBaseTokensWithBalance = UseTokensBase<BaseTokenWithBalance>
 
 interface UseTokensBase<T> {
   tokenDetails: T[]
@@ -156,7 +156,7 @@ export const useNonFungibleTokens = (
 
 export const useFungibleTokens = (
   account?: BaseWalletAccount
-): UseTokens => {
+): UseTokensWithBalance => {
   const {
     tokenDetails: allUserTokens,
     tokenDetailsIsInitialising: allUserTokensIsInitialising,
@@ -227,7 +227,7 @@ export const useFungibleTokens = (
 
 export const useAllTokensWithBalance = (
   account?: BaseWalletAccount
-): UseBaseTokens => {
+): UseBaseTokensWithBalance => {
   const selectedAccount = useAccount(account)
   const networkId = useMemo(() => {
     return selectedAccount?.networkId ?? ""

--- a/packages/extension/src/ui/features/accountTokens/tokens.state.ts
+++ b/packages/extension/src/ui/features/accountTokens/tokens.state.ts
@@ -3,7 +3,6 @@ import { BigNumber } from "ethers"
 import { memoize } from "lodash-es"
 import { useEffect, useMemo, useRef } from "react"
 import useSWR from "swr"
-import useSWRImmutable from 'swr/immutable'
 import { getNetwork, Network } from "../../../shared/network"
 
 import { useArrayStorage, useObjectStorage } from "../../../shared/storage/hooks"

--- a/packages/extension/src/ui/features/accountTokens/tokens.state.ts
+++ b/packages/extension/src/ui/features/accountTokens/tokens.state.ts
@@ -106,7 +106,7 @@ export const useToken = (baseToken: BaseToken): Token | undefined => {
 /** error codes to suppress - will not bubble error up to parent */
 const SUPPRESS_ERROR_STATUS = [429]
 
-export const useNonFungibleTokens = (
+export const useNonFungibleTokensWithBalance = (
   account?: BaseWalletAccount,
 ): BaseTokenWithBalance[] => {
   const selectedAccount = useAccount(account)

--- a/packages/extension/src/ui/features/accountTokens/tokens.state.ts
+++ b/packages/extension/src/ui/features/accountTokens/tokens.state.ts
@@ -154,7 +154,7 @@ export const useNonFungibleTokens = (
   return nonFungibleTokens || []
 }
 
-export const useFungibleTokens = (
+export const useFungibleTokensWithBalance = (
   account?: BaseWalletAccount
 ): UseTokensWithBalance => {
   const {

--- a/packages/extension/src/ui/features/accountTokens/tokens.state.ts
+++ b/packages/extension/src/ui/features/accountTokens/tokens.state.ts
@@ -114,7 +114,7 @@ export const useNonFungibleTokens = (
     return selectedAccount?.networkId ?? ""
   }, [selectedAccount?.networkId])
   const cachedFungibleTokens = useTokensInNetwork(networkId)
-  const { tokenDetails: allUserTokens } = useAllTokens(account)
+  const { tokenDetails: allUserTokens } = useAllTokensWithBalance(account)
 
   const potentialNonFungibleTokens: BaseTokenWithBalance[] = []
   for (const token of allUserTokens) {
@@ -162,7 +162,7 @@ export const useFungibleTokens = (
     tokenDetailsIsInitialising: allUserTokensIsInitialising,
     isValidating: allUserTokensIsValidating,
     error: allUserTokensError
-  } = useAllTokens(account)
+  } = useAllTokensWithBalance(account)
   const selectedAccount = useAccount(account)
   const networkId = useMemo(() => {
     return selectedAccount?.networkId ?? ""
@@ -225,7 +225,7 @@ export const useFungibleTokens = (
   }
 }
 
-export const useAllTokens = (
+export const useAllTokensWithBalance = (
   account?: BaseWalletAccount
 ): UseBaseTokens => {
   const selectedAccount = useAccount(account)

--- a/packages/extension/src/ui/features/actions/ApproveTransactionScreen.tsx
+++ b/packages/extension/src/ui/features/actions/ApproveTransactionScreen.tsx
@@ -17,7 +17,7 @@ import { routes } from "../../routes"
 import { usePageTracking } from "../../services/analytics"
 import { rejectAction } from "../../services/backgroundActions"
 import { Account } from "../accounts/Account"
-import { useAllTokens } from "../accountTokens/tokens.state"
+import { useAllTokensWithBalance } from "../accountTokens/tokens.state"
 import { getLedgerApp } from "../ledger/utils"
 import { useNetwork } from "../networks/useNetworks"
 import { ConfirmScreen } from "./ConfirmScreen"
@@ -210,7 +210,7 @@ export const ApproveTransactionScreen: FC<ApproveTransactionScreenProps> = ({
     "detecting" | "notfound" | "signing" | "succeeded" | "failed"
   >()
   const [ledgerApp, setLedgerApp] = useState<LedgerApp>()
-  const { tokenDetails: allUserTokens, tokenDetailsIsInitialising } = useAllTokens(selectedAccount)
+  const { tokenDetails: allUserTokens, tokenDetailsIsInitialising } = useAllTokensWithBalance(selectedAccount)
 
   // TODO: handle error
   useEffect(() => {

--- a/packages/extension/src/ui/features/send/SendScreen.tsx
+++ b/packages/extension/src/ui/features/send/SendScreen.tsx
@@ -18,7 +18,7 @@ import { showTokenId } from "../accountActivity/transform/transaction/transformT
 import { useSelectedAccount } from "../accounts/accounts.state"
 import { TokenList } from "../accountTokens/TokenList"
 import { Token } from "../../../shared/token/type"
-import { useFungibleTokens } from "../accountTokens/tokens.state"
+import { useFungibleTokensWithBalance } from "../accountTokens/tokens.state"
 
 const SearchBox = styled.form`
   margin-top: 8px;
@@ -53,7 +53,7 @@ export const SendScreen: FC = () => {
 
   const account = useSelectedAccount()
   const currentQueryValue = watch().query
-  const { tokenDetails: fungibleTokens } = useFungibleTokens(account)
+  const { tokenDetails: fungibleTokens } = useFungibleTokensWithBalance(account)
   const tokenList = useCustomTokenList(fungibleTokens, account?.networkId, currentQueryValue)
 
   if (!account) {


### PR DESCRIPTION
Currently we use a dynamic array as the key for `useSWR`, and when the key changes, it leads to cache revalidation, which means we need to re-fetch all data. This PR caches each collection and NFT separately.