### PR TITLE
Navigate to Accounts Page when No Account is Available

### DIFF
--- a/packages/extension/src/ui/features/actions/ApproveTransactionScreen.tsx
+++ b/packages/extension/src/ui/features/actions/ApproveTransactionScreen.tsx
@@ -4,7 +4,7 @@ import { getHDWalletPath } from "@alephium/web3-wallet"
 import { L1, icons } from "@argent/ui"
 import { Flex, Text } from "@chakra-ui/react"
 import { FC, useCallback, useEffect, useState } from "react"
-import { useNavigate } from "react-router-dom"
+import { Navigate, useNavigate } from "react-router-dom"
 
 import {
   ReviewTransactionResult,
@@ -280,7 +280,8 @@ export const ApproveTransactionScreen: FC<ApproveTransactionScreenProps> = ({
   }, [selectedAccount, buildResult, onSubmit, onReject, navigate])
 
   if (!selectedAccount) {
-    throw Error(`No account found for network ${networkId}`)
+    rejectAction(actionHash)
+    return <Navigate to={routes.accounts()} />
   }
 
   if (!buildResult) {


### PR DESCRIPTION
Need to reject the current action before going to the accounts page, otherwise it will end up in a loop, causing black screen. 
See discussion [here](https://github.com/alephium/extension-wallet/pull/188#discussion_r1554619924).