### PR TITLE
Update the state when discover accounts fails

### DIFF
--- a/packages/extension/src/ui/features/accounts/AccountScreenEmpty.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountScreenEmpty.tsx
@@ -44,6 +44,7 @@ export const AccountScreenEmpty: FC<AccountScreenEmptyProps> = ({
       const result = await discoverAccounts(currentNetwork.id)
       if (result === "error") {
         console.log("Error discovering accounts")
+        setDiscoveringAccounts(false)
       } else {
         const discoveredAccounts = mapWalletAccountsToAccounts(result.accounts)
         setAllAccounts(allAccountsOnNetwork.concat(discoveredAccounts))

--- a/packages/extension/src/ui/features/settings/DeveloperSettings.tsx
+++ b/packages/extension/src/ui/features/settings/DeveloperSettings.tsx
@@ -41,6 +41,7 @@ const DeveloperSettings: FC = () => {
       const result = await discoverAccounts(currentNetwork.id)
       if (result === "error") {
         console.log("Error discovering accounts")
+        setLoading(false)
       } else {
         const discoveredAccounts = mapWalletAccountsToAccounts(result.accounts)
         let accountIndex = allWalletAccountsOnNetwork.length


### PR DESCRIPTION
When discover accounts fails, the extension wallet will stay on the loading page forever