### PR TITLE
Remove the `Export private key` button for the ledger account

### DIFF
--- a/packages/extension/src/ui/features/accountEdit/AccountEditScreen.tsx
+++ b/packages/extension/src/ui/features/accountEdit/AccountEditScreen.tsx
@@ -162,13 +162,18 @@ export const AccountEditScreen: FC = () => {
           >
             {showDelete ? t("Delete account") : t("Hide account")}
           </ButtonCell>
-          <ButtonCell
-            color={"error.500"}
-            onClick={() => navigate(routes.exportPrivateKey())}
-            icon={<AlertIcon />}
-          >
-            {t("Export private key")}
-          </ButtonCell>
+          <>
+            {account?.signer.type === 'ledger'
+              ? <></>
+              : <ButtonCell
+                  color={"error.500"}
+                  onClick={() => navigate(routes.exportPrivateKey())}
+                  icon={<AlertIcon />}
+                >
+                  {t("Export private key")}
+                </ButtonCell>
+            }
+          </>
         </CellStack>
       </NavigationContainer>
     </>


### PR DESCRIPTION
The returned private key is generated using the mnemonic of the extension wallet and the hd-index of the ledger account: https://github.com/alephium/extension-wallet/blob/4985bf0dfe30d1a72c69cb28c223180e577ab884/packages/extension/src/background/wallet.ts#L376 so it may or may not be the same as the existing account's private key, depending on whether the hd-index is the same.