### PR TITLE
Fix SWR Cache Quota

### DIFF
--- a/packages/extension/src/shared/account/selectors.ts
+++ b/packages/extension/src/shared/account/selectors.ts
@@ -8,6 +8,11 @@ export const getAccountSelector = memoize(
     accountsEqual(account, baseAccount),
 )
 
+export const getOtherAccountsSelector = memoize(
+  (baseAccount: BaseWalletAccount) => (account: StoredWalletAccount) =>
+    !accountsEqual(account, baseAccount),
+)
+
 export const getNetworkSelector = memoize(
   (networkId: string) => (account: StoredWalletAccount) =>
     account.networkId === networkId,

--- a/packages/extension/src/shared/storage/hooks.ts
+++ b/packages/extension/src/shared/storage/hooks.ts
@@ -85,10 +85,10 @@ export function useArrayStorage<T>(
   )
 
   useEffect(() => {
-    storage.get().then(set)
+    storage.get(selector).then(set)
     const sub = storage.subscribe(set)
     return () => sub()
   }, [selector, storage, set])
 
-  return useMemo(() => value.filter(selector), [value, selector])
+  return value
 }

--- a/packages/extension/src/ui/App.tsx
+++ b/packages/extension/src/ui/App.tsx
@@ -15,11 +15,13 @@ import SoftReloadProvider from "./services/resetAndReload"
 import { useSentryInit } from "./services/sentry"
 import { swrCacheProvider } from "./services/swr"
 import { ThemeProvider, muiTheme } from "./theme"
+import { pruneTransactionsInfiniteScrollCache } from "../shared/transactions"
 
 export const App: FC = () => {
   useTracking()
   useSentryInit()
   updateTokenList()
+  pruneTransactionsInfiniteScrollCache()
 
   return (
     <SoftReloadProvider>


### PR DESCRIPTION
SWR Cache uses the `localStorage` as backend, which has a 10MB limit. The one use the most space is the infinite scroll cache for transactions (~75% for my wallet)

This PR: 

1. Cleanup the infinite scroll cache for accounts other than the selected one
2. For `useArrayStorage`, only cached the selected results instead of all results

