### PR TITLE
Announce the injected provider

### DIFF
--- a/packages/extension/src/inpage/alephiumWindowObject.ts
+++ b/packages/extension/src/inpage/alephiumWindowObject.ts
@@ -116,12 +116,6 @@ export const alephiumWindowObject: AlephiumWindowObject =
         throw Error("User aborted")
       }
 
-      const { alephiumProviders } = window
-      const alephium = alephiumProviders?.alephium
-      if (!alephium) {
-        throw Error("No alephium object detected")
-      }
-
       const account = {
         address: walletAccount.address,
         publicKey: walletAccount.signer.publicKey,

--- a/packages/extension/src/inpage/index.ts
+++ b/packages/extension/src/inpage/index.ts
@@ -52,7 +52,17 @@ function attachNostrProvider() {
   }
 }
 
+function announceProvider() {
+  const event = new CustomEvent('announceAlephiumProvider', {
+    detail: Object.freeze({ provider: alephiumWindowObject })
+  })
+  const handler = () => window.dispatchEvent(event)
+  handler()
+  window.addEventListener('requestAlephiumProvider', handler)
+}
+
 function attach() {
+  announceProvider()
   attachAlephiumProvider()
   attachNostrProvider()
 }
@@ -62,15 +72,8 @@ attach()
 window.addEventListener(
   "message",
   async ({ data }: MessageEvent<WindowMessageType>) => {
-    const { alephiumProviders } = window
-    const alephium = alephiumProviders?.alephium
-
-    if (!alephium) {
-      return
-    }
-
     if (data.type === "ALPH_DISCONNECT_ACCOUNT") {
-      await alephium.disconnect()
+      await alephiumWindowObject.disconnect()
     }
   },
 )

--- a/packages/extension/src/inpage/inpage.model.ts
+++ b/packages/extension/src/inpage/inpage.model.ts
@@ -43,6 +43,11 @@ declare global {
     alephiumProviders?: Record<string, AlephiumWindowObject>
     nostr?: NostrObject
   }
+
+  interface WindowEventMap {
+    'announceAlephiumProvider': CustomEvent,
+    'requestAlephiumProvider': Event
+  }
 }
 
 export interface NostrObject {


### PR DESCRIPTION
Since the `window.alephiumProviders` is set by different wallets, when both the onekey extension wallet and the alephium extension wallet are enabled at the same time, `window.alephiumProviders.alephium` becomes `undefined` (possibly because in the onekey, `window.alephiumProviders` is set to [non-configurable](https://github.com/OneKeyHQ/cross-inpage-provider/blob/23a0e8e3ef2ace42e8a0359be49ddfd2a653d281/packages/core/src/walletProperty.ts#L127), and in the alephium wallet, `window.alephiumProviders.alephium` is set to [non-writable](https://github.com/alephium/extension-wallet/blob/3793ee9dc227e889a148289fe7101176ffd44aa2/packages/extension/src/inpage/index.ts#L24)). This PR adopts the [EIP6963](https://eips.ethereum.org/EIPS/eip-6963) approach to make it easier for dApps to detect injected providers.