### PR TITLE
Make injection of inpage.js on dapps synchronous

### DIFF
--- a/packages/extension/manifest/v3.json
+++ b/packages/extension/manifest/v3.json
@@ -13,11 +13,17 @@
     "default_title": "Alephium",
     "default_popup": "index.html"
   },
+  "host_permissions": [
+    "file://*/*",
+    "http://*/*",
+    "https://*/*"
+  ],
   "permissions": [
     "alarms",
     "tabs",
     "storage",
     "notifications",
+    "scripting",
     "http://localhost/*",
     "https://node.testnet.alephium.org/*",
     "https://backend.testnet.alephium.org/*",

--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -197,3 +197,24 @@ messageStream.subscribe(async ([msg, sender]) => {
 // open onboarding flow on initial install
 
 initOnboarding()
+
+const registerInPageContentScript = async () => {
+  try {
+    await browser.scripting.registerContentScripts([
+      {
+        id: 'inpage',
+        matches: ["<all_urls>"],
+        js: ['inpage.js'],
+        runAt: 'document_start',
+        world: 'MAIN',
+        allFrames: true,
+      },
+    ]);
+  } catch (err) {
+    console.warn(`Dropped attempt to register inpage content script. ${err}`);
+  }
+};
+
+if (browser.runtime.getManifest().manifest_version === 3) {
+  registerInPageContentScript();
+}

--- a/packages/extension/src/content.ts
+++ b/packages/extension/src/content.ts
@@ -4,14 +4,21 @@ import { WindowMessageType } from "./shared/messages"
 import { messageStream, sendMessage } from "./shared/messages"
 
 const container = document.head || document.documentElement
-const script = document.createElement("script")
-
-script.src = browser.runtime.getURL("inpage.js")
 const alephiumExtensionId = browser.runtime.id
-script.id = "alephium-extension"
-script.setAttribute("data-extension-id", alephiumExtensionId)
 
-container.insertBefore(script, container.children[0])
+let tag: HTMLElement
+if (browser.runtime.getManifest().manifest_version === 3) {
+  const divTag = document.createElement("div")
+  divTag.style.display = 'none'
+  tag = divTag
+} else {
+  const scriptTag = document.createElement("script")
+  scriptTag.src = browser.runtime.getURL("inpage.js")
+  tag = scriptTag
+}
+tag.id = 'alephium-extension'
+tag.setAttribute('data-extension-id', alephiumExtensionId)
+container.insertBefore(tag, container.children[0])
 
 window.addEventListener(
   "message",


### PR DESCRIPTION
Due to [this issue](https://issues.chromium.org/issues/41267807), the execution of `inpage.js` is sometimes asynchronous, which prevents the dApp from detecting injected providers on time. This PR fixes the issue by referencing [MetaMask's implementation](https://github.com/MetaMask/metamask-extension/pull/15448).