### PR TITLE
Revert "Make injection of inpage.js on dapps synchronous"

### DIFF
--- a/packages/extension/manifest/v3.json
+++ b/packages/extension/manifest/v3.json
@@ -13,17 +13,11 @@
     "default_title": "Alephium",
     "default_popup": "index.html"
   },
-  "host_permissions": [
-    "file://*/*",
-    "http://*/*",
-    "https://*/*"
-  ],
   "permissions": [
     "alarms",
     "tabs",
     "storage",
     "notifications",
-    "scripting",
     "http://localhost/*",
     "https://node.testnet.alephium.org/*",
     "https://backend.testnet.alephium.org/*",

--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -197,24 +197,3 @@ messageStream.subscribe(async ([msg, sender]) => {
 // open onboarding flow on initial install
 
 initOnboarding()
-
-const registerInPageContentScript = async () => {
-  try {
-    await browser.scripting.registerContentScripts([
-      {
-        id: 'inpage',
-        matches: ["<all_urls>"],
-        js: ['inpage.js'],
-        runAt: 'document_start',
-        world: 'MAIN',
-        allFrames: true,
-      },
-    ]);
-  } catch (err) {
-    console.warn(`Dropped attempt to register inpage content script. ${err}`);
-  }
-};
-
-if (browser.runtime.getManifest().manifest_version === 3) {
-  registerInPageContentScript();
-}

--- a/packages/extension/src/content.ts
+++ b/packages/extension/src/content.ts
@@ -4,21 +4,14 @@ import { WindowMessageType } from "./shared/messages"
 import { messageStream, sendMessage } from "./shared/messages"
 
 const container = document.head || document.documentElement
-const alephiumExtensionId = browser.runtime.id
+const script = document.createElement("script")
 
-let tag: HTMLElement
-if (browser.runtime.getManifest().manifest_version === 3) {
-  const divTag = document.createElement("div")
-  divTag.style.display = 'none'
-  tag = divTag
-} else {
-  const scriptTag = document.createElement("script")
-  scriptTag.src = browser.runtime.getURL("inpage.js")
-  tag = scriptTag
-}
-tag.id = 'alephium-extension'
-tag.setAttribute('data-extension-id', alephiumExtensionId)
-container.insertBefore(tag, container.children[0])
+script.src = browser.runtime.getURL("inpage.js")
+const alephiumExtensionId = browser.runtime.id
+script.id = "alephium-extension"
+script.setAttribute("data-extension-id", alephiumExtensionId)
+
+container.insertBefore(script, container.children[0])
 
 window.addEventListener(
   "message",


### PR DESCRIPTION
We introduced this change to address the issue of asynchronous loading of `inpage.js`. However, this change causes the extension background to be unable to receive connection messages [sent by the dApp](https://github.com/alephium/extension-wallet/blob/e3f10da92580e7f6447c27c6d158f6ac46301b55/packages/extension/src/inpage/alephiumWindowObject.ts#L99) when the extension's server worker restarts. I’m still unclear about the exact reason behind this.

Previously, I noticed that Rabby wallet also used [the same approach](https://github.com/RabbyHub/Rabby/pull/2124/files#diff-c2bc594732c44dc792b7dfa8a9dcb11035d3b29aee71292e2f046862264f0bceR80) to inject `inpage.js`. However, for unknown reasons, they reverted this change in [a later PR](https://github.com/RabbyHub/Rabby/pull/2130/files).

I will look into alternative methods to solve the issue of asynchronous loading of `inpage.js`.