### PR TITLE
Fix Public Key Mismatch Issue

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/*"],
-  "version": "0.9.18",
+  "version": "0.9.19",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.9.18",
+  "version": "0.9.19",
   "private": true,
   "name": "alephium-browser-extension-wallet",
   "repository": "github:alephium/extension-wallet",

--- a/packages/dapp/package.json
+++ b/packages/dapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alephium/dapp",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packages/extension/manifest/v2.json
+++ b/packages/extension/manifest/v2.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/chrome-manifest.json",
   "name": "Alephium Extension Wallet",
   "description": "Alephium's official extension wallet with powerful features and a clean UI.",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "manifest_version": 2,
   "browser_action": {
     "default_icon": {

--- a/packages/extension/manifest/v3.json
+++ b/packages/extension/manifest/v3.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/chrome-manifest.json",
   "name": "Alephium Extension Wallet",
   "description": "Alephium's official extension wallet with powerful features and a clean UI.",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "manifest_version": 3,
   "action": {
     "default_icon": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alephium/extension",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
@@ -81,8 +81,8 @@
     "push-release-branch": "git push --set-upstream origin release/v$npm_package_version --follow-tags"
   },
   "dependencies": {
-    "@argent/stack-router": "^0.9.18",
-    "@argent/ui": "^0.9.18",
+    "@argent/stack-router": "^0.9.19",
+    "@argent/ui": "^0.9.19",
     "@chakra-ui/icons": "^2.0.15",
     "@chakra-ui/react": "2.5.1",
     "@extend-chrome/messages": "^1.2.2",

--- a/packages/extension/src/background/actionHandlers.ts
+++ b/packages/extension/src/background/actionHandlers.ts
@@ -62,10 +62,11 @@ export const handleActionApproval = async (
 
         let results: TransactionResult[]
         if (transactions.length === 1) {
-          const transaction = transactions[0] as ReviewTransactionResult
+          const transaction = transactions[0] as ReviewTransactionResult & { signature?: string }
 
           const { signature } = await executeTransactionAction(
             transaction,
+            transaction.signature,
             background,
             transaction.params.networkId,
           )

--- a/packages/extension/src/ui/features/actions/ApproveTransactionScreen.tsx
+++ b/packages/extension/src/ui/features/actions/ApproveTransactionScreen.tsx
@@ -25,7 +25,7 @@ import { tryBuildChainedTransactions, tryBuildTransactions } from "../../../shar
 import { IconButton } from "@mui/material"
 import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons"
 import { getAccounts } from "../../../shared/account/store"
-import { useSelectedAccount } from "../accounts/accounts.state"
+import { useAccount, useSelectedAccount } from "../accounts/accounts.state"
 import { LedgerStatus } from "./LedgerStatus"
 import { useLedgerApp } from "../ledger/useLedgerApp"
 import { getConfirmationTextByState } from "../ledger/types"
@@ -50,7 +50,20 @@ export const ApproveTransactionScreen: FC<ApproveTransactionScreenProps> = ({
 }) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const selectedAccount = useSelectedAccount()
+  const selectedAccount0 = useSelectedAccount()
+
+  const getSignerAccount = useCallback(() => {
+    if (transactionParams.length == 1) {
+      return {
+        address: transactionParams[0].params.signerAddress,
+        networkId: transactionParams[0].params.networkId
+      }
+    }
+    return undefined
+  }, [transactionParams])
+
+  const signerAccount = useAccount(getSignerAccount())
+  const selectedAccount = signerAccount ?? selectedAccount0
 
   usePageTracking("signTransaction", {
     networkId: selectedAccount?.networkId || "unknown",

--- a/packages/extension/src/ui/features/actions/ApproveTransactionScreen.tsx
+++ b/packages/extension/src/ui/features/actions/ApproveTransactionScreen.tsx
@@ -53,7 +53,7 @@ export const ApproveTransactionScreen: FC<ApproveTransactionScreenProps> = ({
   const selectedAccount0 = useSelectedAccount()
 
   const getSignerAccount = useCallback(() => {
-    if (transactionParams.length == 1) {
+    if (transactionParams.length === 1) {
       return {
         address: transactionParams[0].params.signerAddress,
         networkId: transactionParams[0].params.networkId

--- a/packages/stack-router/package.json
+++ b/packages/stack-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/stack-router",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "license": "MIT",
   "private": true,
   "files": [
@@ -32,7 +32,7 @@
     "lodash-es": "^4.17.21"
   },
   "devDependencies": {
-    "@argent/ui": "^0.9.18",
+    "@argent/ui": "^0.9.19",
     "@types/lodash-es": "^4.17.6",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@argent-x/storybook",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "private": true,
   "devDependencies": {
-    "@alephium/extension": "^0.9.18",
-    "@argent/ui": "^0.9.18",
+    "@alephium/extension": "^0.9.19",
+    "@argent/ui": "^0.9.19",
     "@babel/core": "^7.18.5",
     "@chakra-ui/storybook-addon": "^4.0.12",
     "@storybook/addon-actions": "^6.5.9",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/ui",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "license": "MIT",
   "private": true,
   "files": [


### PR DESCRIPTION
Fix the public key mismatch issue mentioned here: https://github.com/alephium/alephium-frontend/issues/1297

We will first try to use the signer address in the transaction param to get the selected account, so even if we switch the selected account in the wallet while connected to a dApp it will still sign using the connected account. 

For dApp initiated chained transaction (`transactionParams > 1`), it will always use the address in transaction params.