### PR TITLE
Lower the Number of Persisted Transactions Per Account

### DIFF
--- a/packages/extension/src/background/transactions/sources/onchain.ts
+++ b/packages/extension/src/background/transactions/sources/onchain.ts
@@ -73,7 +73,7 @@ export function getUpdatesFromLatestTransactions(
 export function getPruneTransactions(
   existingTransactions: Transaction[],
 ): TransactionUpdates {
-  const maxPersistedTxsPerWalletAccount = 50
+  const maxPersistedTxsPerWalletAccount = 25
   const transactionsByWalletAccount = groupBy(existingTransactions, (tx) => `${tx.account.address}-${tx.account.networkId}`)
   const transactionsToPrune: Transaction[] = []
   forEach(transactionsByWalletAccount, (transactionsPerWalletAccount, _) => {


### PR DESCRIPTION
Some of the heavy users still hit the `core:transactions` quota issue:

```
Failed to execute `setItem` on storage: setting the value of "core:transactions" exceed the quota
```

Lower the number of persisted tx per account from `50` to `25` to prune more aggressively.