### PR TITLE
Tolerant to failures in the explorer backend API

### DIFF
--- a/packages/extension/locales/en-US/translation.json
+++ b/packages/extension/locales/en-US/translation.json
@@ -262,6 +262,8 @@
   "Selected network": "Selected network",
   "Network issues": "Network issues",
   "There are connectivity issues for Alephium explorer or full node at the moment on {{ network }}": "There are connectivity issues for Alephium explorer or full node at the moment on {{ network }}",
+  "There are connectivity issues for Alephium explorer at the moment on {{ network }}": "There are connectivity issues for Alephium explorer at the moment on {{ network }}",
+  "There are connectivity issues for Alephium full node at the moment on {{ network }}": "There are connectivity issues for Alephium full node at the moment on {{ network }}",
   "I understand": "I understand",
   "Pin the Alephium extension for quick access": "Pin the Alephium extension for quick access",
   "Alephium": "Alephium",

--- a/packages/extension/src/shared/network/type.ts
+++ b/packages/extension/src/shared/network/type.ts
@@ -8,7 +8,13 @@ export interface Network {
   readonly?: boolean
 }
 
+export interface NetworkHealthStatus {
+  nodeHealthy: boolean
+  explorerHealthy: boolean
+}
 export interface NetworkStatus {
   id: Network['id']
   healthy: boolean
+  nodeHealthy: boolean
+  explorerHealthy: boolean
 }

--- a/packages/extension/src/ui/features/accountNfts/alephium-nft.service.ts
+++ b/packages/extension/src/ui/features/accountNfts/alephium-nft.service.ts
@@ -10,10 +10,9 @@ export const fetchCollectionAndNfts = async (
   nftIds: string[],
   network: Network
 ): Promise<CollectionAndNFTMap> => {
-  const explorerProvider = new ExplorerProvider(network.explorerApiUrl)
   const parentAndTokenIds: CollectionAndNFTMap = {}
 
-  const nftMetadataz = await getNftMetadataz(nftIds, explorerProvider)
+  const nftMetadataz = await getNftMetadataz(nftIds, network)
   for (const nftMetadata of nftMetadataz) {
     const tokenId = nftMetadata.id
     const collectionId = nftMetadata.collectionId
@@ -75,10 +74,13 @@ async function getCollectionMetadata(
   return await metadataResponse.json()
 }
 
-async function getNftMetadataz(nftIds: string[], explorerProvider: ExplorerProvider) {
-  const maxSizeTokens = 80
+export async function getNftMetadataz(nftIds: string[], network: Network): Promise<NFTMetadata[]> {
+  const explorerProvider = new ExplorerProvider(network.explorerApiUrl)
+  const nodeProvider = new NodeProvider(network.nodeUrl, network.nodeApiKey)
+
   const cachedNftMetadataz: NFTMetadata[] = []
   const nftIdsWithoutMetadata: string[] = []
+
   for (const nftId of nftIds) {
     const metadata = await getImmutable<NFTMetadata>(`${nftId}-nft-metadata`)
     if (metadata?.id) {
@@ -88,19 +90,59 @@ async function getNftMetadataz(nftIds: string[], explorerProvider: ExplorerProvi
     }
   }
 
+  if (nftIdsWithoutMetadata.length === 0) {
+    return cachedNftMetadataz
+  }
+
+  try {
+    const newNftMetadataz = await getNftMetadatazWithExplorerBackend(nftIdsWithoutMetadata, explorerProvider)
+    return cachedNftMetadataz.concat(newNftMetadataz)
+  } catch (error) {
+    console.log(`Explorer backend failed, falling back to full node: ${error}`)
+    const newNftMetadataz = await getNftMetadatazWithFullNode(nftIdsWithoutMetadata, nodeProvider)
+    return cachedNftMetadataz.concat(newNftMetadataz)
+  }
+}
+
+async function getNftMetadatazWithExplorerBackend(nftIds: string[], explorerProvider: ExplorerProvider) {
+  const maxSizeTokens = 80
   const newNftMetadataz: NFTMetadata[] = []
-  if (nftIdsWithoutMetadata.length !== 0) {
-    for (const ids of chunk(nftIdsWithoutMetadata, maxSizeTokens)) {
-      const newMetadataz = await explorerProvider.tokens.postTokensNftMetadata(ids)
-      newNftMetadataz.push(...newMetadataz)
-      for (const newMetadata of newMetadataz) {
-        await storeImmutable(`${newMetadata.id}-nft-metadata`, newMetadata)
-      }
+
+  for (const ids of chunk(nftIds, maxSizeTokens)) {
+    const newMetadataz = await explorerProvider.tokens.postTokensNftMetadata(ids)
+    newNftMetadataz.push(...newMetadataz)
+    for (const newMetadata of newMetadataz) {
+      await storeImmutable(`${newMetadata.id}-nft-metadata`, newMetadata)
     }
   }
 
-  return cachedNftMetadataz.concat(newNftMetadataz)
+  return newNftMetadataz
 }
+
+export async function getNftMetadatazWithFullNode(nftIds: string[], nodeProvider: NodeProvider): Promise<NFTMetadata[]> {
+  // Fetch missing metadata from full node (one by one since there's no batch endpoint)
+  const newNftMetadataz: NFTMetadata[] = []
+
+  for (const nftId of nftIds) {
+    try {
+      const nftMetadata = await nodeProvider.fetchNFTMetaData(nftId)
+      const metadata: NFTMetadata = {
+        id: nftId,
+        collectionId: nftMetadata.collectionId,
+        tokenUri: nftMetadata.tokenUri,
+        nftIndex: nftMetadata.nftIndex.toString()
+      }
+      newNftMetadataz.push(metadata)
+      await storeImmutable(`${metadata.id}-nft-metadata`, metadata)
+    } catch (error) {
+      console.error(`Error fetching NFT metadata for ${nftId} from full node: ${error}`)
+      // Continue with other NFTs even if one fails
+    }
+  }
+
+  return newNftMetadataz
+}
+
 
 export const isMp4Url = (url: string) => {
   return url.toLowerCase().endsWith('.mp4')

--- a/packages/extension/src/ui/features/networks/NetworkWarningScreen.tsx
+++ b/packages/extension/src/ui/features/networks/NetworkWarningScreen.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from "react-router-dom"
 
 import { routes, useReturnTo } from "../../routes"
 import { useNeedsToShowNetworkStatusWarning } from "./seenNetworkStatusWarning.state"
-import { useCurrentNetwork } from "./useNetworks"
+import { useCurrentNetwork, useNetworkStatuses } from "./useNetworks"
 import { useTranslation } from "react-i18next"
 
 const { NetworkIcon } = icons
@@ -15,8 +15,21 @@ export const NetworkWarningScreen: FC = () => {
   const navigate = useNavigate()
   const returnTo = useReturnTo()
   const network = useCurrentNetwork()
+  const { networkStatuses } = useNetworkStatuses()
   const [, updateNeedsToShowNetworkStatusWarning] =
     useNeedsToShowNetworkStatusWarning()
+
+  const currentNetworkStatus = networkStatuses[network.id]
+
+  const hasExplorerIssues = currentNetworkStatus && !currentNetworkStatus.explorerHealthy
+  const hasNodeIssues = currentNetworkStatus && !currentNetworkStatus.nodeHealthy
+
+  let message = t("There are connectivity issues for Alephium explorer or full node at the moment on {{ network }}", { network: network.name })
+  if (hasExplorerIssues && !hasNodeIssues) {
+    message = t("There are connectivity issues for Alephium explorer at the moment on {{ network }}", { network: network.name })
+  } else if (hasNodeIssues && !hasExplorerIssues) {
+    message = t("There are connectivity issues for Alephium full node at the moment on {{ network }}", { network: network.name })
+  }
 
   return (
     <Center flex={1} flexDirection={"column"} py={6} px={5}>
@@ -39,7 +52,7 @@ export const NetworkWarningScreen: FC = () => {
           {t("Network issues")}
         </H3>
         <P3 color="neutrals.100">
-          {t("There are connectivity issues for Alephium explorer or full node at the moment on {{ network }}", { network: network.name })}
+          {message}
         </P3>
       </Center>
       <Button


### PR DESCRIPTION
When Explorer Backend API is down, extension wallet is still able to:

1. Display token balances
2. Display NFTs
3. Send and receive assets
4. Interact with dApp

Extension wallet will only be able to show transaction history when Explorer Backend API becomes operational again. 